### PR TITLE
feat: QR-JWT device-token login + NTAG424 card provisioning (closes #4)

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add to ~/.sdkman/etc/config: sdkman_auto_env=true
+java=11.0.26-zulu

--- a/README.md
+++ b/README.md
@@ -27,26 +27,92 @@ Download the compiled APK from the [latest release](https://github.com/boltcard/
 
 Download from the [Google Play store](https://play.google.com/store/apps/details?id=com.lacrypta.cardinstaller&hl=en&gl=US)
 
-## Setup & Run instructions for Linux with Android
+## Pinned toolchain
 
-### Build instructions
+This project is locked to a specific build toolchain. Versions are declared in repo
+config and consumed automatically by the helper scripts — no manual env-var juggling.
 
-1. Install android studio https://developer.android.com/studio
-2. Install Android 12 SDK version 31 reference: https://reactnative.dev/docs/environment-setup
-   “Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the Android 12 (S) SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.“
-3. Install Google APIs Intel x86 Atom_64 System Image
-4. Install node v14.X or v16.X (v14.20.0 & v16.14.2 are working)
-5. Install NPX https://www.npmjs.com/package/npx
-6. Install Yarn https://yarnpkg.com/
-7. Might also be needed: $ sudo corepack enable
-8. Install JDK $sudo apt install default-jdk
-9. clone repo to dir
-10. cd to dir and run yarn (might be some warnings)
-11. connect android phone to USB and enable USB debugging on phone.
-12. in the terminal type $npx react-native start
-13. Register an app key for the Taplinx SDK library on https://inspire.nxp.com/mifare/
-14. Rename .env-example to .env and set the Mifare package key in this file
-15. open another terminal in same dir and type $npx react-native run-android
+| Tool                | Version              | Source of truth                                   |
+| ------------------- | -------------------- | ------------------------------------------------- |
+| Java                | Zulu 11.0.26         | `.sdkmanrc`                                       |
+| Node                | 18.15                | `.nvmrc`, `.node-version`                         |
+| Yarn                | 1.x (classic)        | installed by `scripts/setup.sh`                   |
+| Gradle              | 7.5.1                | `android/gradle/wrapper/gradle-wrapper.properties`|
+| Android Gradle Plugin | 7.3.1              | `android/build.gradle`                            |
+| Kotlin              | 1.7.0                | `android/gradle.properties`                       |
+| Android SDK         | API 31 (Android 12)  | `android/build.gradle`                            |
+| Build Tools         | 33.0.0               | `android/build.gradle`                            |
+| NDK                 | 23.1.7779620         | `android/build.gradle`                            |
+
+Bumping any of these is a deliberate change — they're committed to git and shared
+across machines.
+
+## Quick start
+
+### One-shot setup (new machine)
+
+Requires Android Studio + Android SDK installed separately
+(see https://reactnative.dev/docs/environment-setup → "React Native CLI Quickstart").
+
+```bash
+git clone <repo>
+cd bolt-nfc-android-app
+yarn setup       # installs SDKMAN, nvm, Zulu 11, Node 18.15, yarn, JS deps
+```
+
+The setup script is idempotent — safe to re-run after pulling changes.
+
+After setup:
+1. Edit `.env` and set your `MIFARE_KEY` (register at https://inspire.nxp.com/mifare/).
+2. Connect an Android device with USB debugging enabled, or start an emulator.
+3. Build & run (see commands below).
+
+### Day-to-day commands
+
+```bash
+yarn build:debug     # build debug APK (no install)
+yarn build:release   # build signed release APK
+yarn build:bundle    # build AAB for Google Play
+yarn android         # build + install debug on connected device/emulator
+yarn start           # start Metro bundler
+yarn clean           # gradle clean
+yarn clean:full      # nuke gradle daemons + local caches (use after JDK changes)
+```
+
+All build commands route through `./scripts/build`, which sets `JAVA_HOME` to a
+JDK 11 install automatically (via SDKMAN, then macOS `java_home`, then known
+Linux JDK paths). You don't need to set `JAVA_HOME` manually.
+
+### Deploying a release
+
+1. Place your upload keystore at `android/app/my-upload-key.keystore`
+   (signing config + credentials are in `android/gradle.properties`).
+2. `yarn build:bundle` → produces `android/app/build/outputs/bundle/release/app-release.aab`
+3. Upload the AAB to Google Play Console.
+
+For first-time keystore generation:
+```bash
+keytool -genkeypair -v -keystore android/app/my-upload-key.keystore \
+  -alias onesandzeros-key -keyalg RSA -keysize 2048 -validity 10000
+```
+
+### Manual setup (if you don't want yarn setup)
+
+<details>
+<summary>Click to expand</summary>
+
+1. Install Android Studio + Android 12 (API 31) SDK, build-tools 33.0.0, NDK 23.1.7779620
+2. Install SDKMAN: `curl -s https://get.sdkman.io | bash`
+3. In the repo root, run `sdk env install` (reads `.sdkmanrc`, installs Zulu 11)
+4. Install nvm: https://github.com/nvm-sh/nvm
+5. In the repo root, run `nvm install` (reads `.nvmrc`, installs Node 18.15)
+6. `npm install -g yarn`
+7. `yarn install`
+8. `cp .env-example .env` and set `MIFARE_KEY` (register at https://inspire.nxp.com/mifare/)
+9. Connect device or start emulator
+10. `yarn android`
+
+</details>
 
 ## Usage
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -188,6 +188,7 @@ dependencies {
     implementation group: 'com.madgag.spongycastle', name: 'core', version: '1.54.0.0'
 
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.0.0")
+    implementation "androidx.security:security-crypto:1.1.0-alpha06"
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}")
     debugImplementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {
         exclude group:'com.squareup.okhttp3', module:'okhttp'

--- a/android/app/src/main/java/com/lightningnfcapp/MyReactPackage.java
+++ b/android/app/src/main/java/com/lightningnfcapp/MyReactPackage.java
@@ -22,6 +22,7 @@ public class MyReactPackage implements ReactPackage {
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();
         modules.add(new MyReactModule(reactContext));
+        modules.add(new SecureStorageModule(reactContext));
         return modules;
     }
 

--- a/android/app/src/main/java/com/lightningnfcapp/SecureStorageModule.java
+++ b/android/app/src/main/java/com/lightningnfcapp/SecureStorageModule.java
@@ -1,0 +1,123 @@
+package com.lacrypta.cardinstaller;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.util.Log;
+
+import androidx.security.crypto.EncryptedSharedPreferences;
+import androidx.security.crypto.MasterKey;
+
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+public class SecureStorageModule extends ReactContextBaseJavaModule {
+
+    private static final String PREFS_FILE = "cardinstaller_secure_prefs";
+
+    private SharedPreferences encryptedPrefs = null;
+
+    public SecureStorageModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    public String getName() {
+        return "SecureStorageModule";
+    }
+
+    private synchronized SharedPreferences getPrefs() throws GeneralSecurityException, IOException {
+        if (encryptedPrefs == null) {
+            encryptedPrefs = buildPrefs();
+        }
+        return encryptedPrefs;
+    }
+
+    private SharedPreferences buildPrefs() throws GeneralSecurityException, IOException {
+        Context ctx = getReactApplicationContext().getApplicationContext();
+        MasterKey masterKey = new MasterKey.Builder(ctx)
+                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                .build();
+        return EncryptedSharedPreferences.create(
+                ctx,
+                PREFS_FILE,
+                masterKey,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        );
+    }
+
+    // On Keystore corruption (OEM bugs, credential reset), clear the prefs and rebuild.
+    private synchronized void recoverFromCorruption() {
+        encryptedPrefs = null;
+        Context ctx = getReactApplicationContext().getApplicationContext();
+        if (Build.VERSION.SDK_INT >= 24) {
+            ctx.deleteSharedPreferences(PREFS_FILE);
+        } else {
+            ctx.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE).edit().clear().commit();
+        }
+        try {
+            encryptedPrefs = buildPrefs();
+        } catch (Exception e) {
+            Log.e(Constants.TAG, "SecureStorage: failed to rebuild after corruption", e);
+        }
+    }
+
+    @ReactMethod
+    public void setItem(String key, String value, Promise promise) {
+        try {
+            getPrefs().edit().putString(key, value).apply();
+            promise.resolve(null);
+        } catch (GeneralSecurityException | IOException e) {
+            Log.w(Constants.TAG, "SecureStorage.setItem: corruption detected, retrying", e);
+            recoverFromCorruption();
+            try {
+                getPrefs().edit().putString(key, value).apply();
+                promise.resolve(null);
+            } catch (Exception e2) {
+                promise.reject("E_SECURE_STORAGE_SET", e2.getMessage(), e2);
+            }
+        }
+    }
+
+    @ReactMethod
+    public void getItem(String key, Promise promise) {
+        try {
+            promise.resolve(getPrefs().getString(key, null));
+        } catch (GeneralSecurityException | IOException e) {
+            Log.w(Constants.TAG, "SecureStorage.getItem: corruption detected, clearing store", e);
+            recoverFromCorruption();
+            // Return null so the caller treats it as "no stored value" and forces re-login.
+            promise.resolve(null);
+        }
+    }
+
+    @ReactMethod
+    public void removeItem(String key, Promise promise) {
+        try {
+            getPrefs().edit().remove(key).apply();
+            promise.resolve(null);
+        } catch (GeneralSecurityException | IOException e) {
+            Log.w(Constants.TAG, "SecureStorage.removeItem: corruption detected, clearing store", e);
+            recoverFromCorruption();
+            promise.resolve(null);
+        }
+    }
+
+    @ReactMethod
+    public void clear(Promise promise) {
+        try {
+            getPrefs().edit().clear().apply();
+            promise.resolve(null);
+        } catch (GeneralSecurityException | IOException e) {
+            Log.w(Constants.TAG, "SecureStorage.clear: corruption detected, force clearing", e);
+            recoverFromCorruption();
+            promise.resolve(null);
+        }
+    }
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,14 +4,14 @@ buildscript {
     ext {
         buildToolsVersion = "33.0.0"
         minSdkVersion = 23
-        compileSdkVersion = 31
-        targetSdkVersion = 31
+        compileSdkVersion = 33
+        targetSdkVersion = 33
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
         ndkVersion = "23.1.7779620"
 
-        VisionCameraCodeScanner_targetSdkVersion = 31 //add
-        VisionCameraCodeScanner_compileSdkVersion = 31 //add
+        VisionCameraCodeScanner_targetSdkVersion = 33 //add
+        VisionCameraCodeScanner_compileSdkVersion = 33 //add
     }
     repositories {
         google()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "33.0.0"
-        minSdkVersion = 21
+        minSdkVersion = 23
         compileSdkVersion = 31
         targetSdkVersion = 31
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -12,6 +12,11 @@
 # Default value: -Xmx512m -XX:MaxMetaspaceSize=256m
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
 
+# JDK requirement: Zulu 11 (required by AGP 7.3.1 / Gradle 7.5.1 / Kotlin 1.7.0).
+# Use SDKMAN to manage the JDK — run `sdk env` in the repo root (auto-handled by
+# .sdkmanrc when sdkman_auto_env=true). The wrapper script `./scripts/build` will
+# also set JAVA_HOME automatically. Do NOT hardcode an absolute path here.
+
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/package.json
+++ b/package.json
@@ -3,13 +3,19 @@
   "version": "0.1.9",
   "private": true,
   "scripts": {
+    "setup": "./scripts/setup.sh",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "lint": "eslint .",
     "start": "react-native start",
     "postinstall": "rn-nodeify --install buffer,process,stream,crypto,events --hack",
     "test": "jest",
-    "commit-hash": "echo \"{\\\"commit\\\":\\\"`git rev-parse --short HEAD`\\\"}\" > gitinfo.json"
+    "commit-hash": "echo \"{\\\"commit\\\":\\\"`git rev-parse --short HEAD`\\\"}\" > gitinfo.json",
+    "build:debug": "./scripts/build debug",
+    "build:release": "./scripts/build release",
+    "build:bundle": "./scripts/build bundle",
+    "clean": "./scripts/build clean",
+    "clean:full": "./scripts/build stop && rm -rf android/.gradle android/build android/app/build"
   },
   "dependencies": {
     "@react-native-clipboard/clipboard": "^1.10.0",

--- a/scripts/build
+++ b/scripts/build
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Build wrapper — guarantees Gradle runs with the right JDK regardless of
+# how the user's shell is configured. Use this when SDKMAN auto-env isn't active.
+#
+# Usage:
+#   ./scripts/build debug    # assembleDebug
+#   ./scripts/build release  # assembleRelease
+#   ./scripts/build bundle   # bundleRelease (AAB for Play Store)
+#   ./scripts/build clean    # ./gradlew clean
+#   ./scripts/build <args>   # passthrough: ./scripts/build app:assembleDebug --info
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_DIR/android"
+
+# Resolve JAVA_HOME to a JDK 11 install, in priority order:
+#   1. SDKMAN candidate (if SDKMAN is active and .sdkmanrc applied)
+#   2. macOS: /usr/libexec/java_home -v 11
+#   3. Common Linux locations (Zulu, Temurin, Adoptium, system)
+resolve_java_home() {
+  # SDKMAN
+  if [ -n "${SDKMAN_DIR:-}" ] && [ -L "$SDKMAN_DIR/candidates/java/current" ]; then
+    local sdkman_java
+    sdkman_java="$(readlink -f "$SDKMAN_DIR/candidates/java/current" 2>/dev/null || readlink "$SDKMAN_DIR/candidates/java/current")"
+    if "$sdkman_java/bin/java" -version 2>&1 | grep -q 'version "11'; then
+      echo "$sdkman_java"; return 0
+    fi
+  fi
+
+  # macOS java_home
+  if [ -x /usr/libexec/java_home ]; then
+    local mac_java
+    if mac_java="$(/usr/libexec/java_home -v 11 2>/dev/null)"; then
+      echo "$mac_java"; return 0
+    fi
+  fi
+
+  # Linux fallbacks
+  for cand in \
+      /usr/lib/jvm/zulu-11* \
+      /usr/lib/jvm/temurin-11* \
+      /usr/lib/jvm/java-11-openjdk* \
+      /opt/zulu-11* \
+      /opt/jdk-11*; do
+    if [ -x "$cand/bin/java" ]; then
+      echo "$cand"; return 0
+    fi
+  done
+
+  return 1
+}
+
+if ! JAVA_HOME="$(resolve_java_home)"; then
+  echo "✗ Could not find a JDK 11 install." >&2
+  echo "  Run ./scripts/setup.sh to install one via SDKMAN, or install Zulu 11 manually." >&2
+  exit 1
+fi
+export JAVA_HOME
+export PATH="$JAVA_HOME/bin:$PATH"
+
+echo "▸ Using JAVA_HOME=$JAVA_HOME"
+echo "▸ $($JAVA_HOME/bin/java -version 2>&1 | head -1)"
+
+# Map shortcut names to gradle tasks
+case "${1:-}" in
+  ""|help|-h|--help)
+    cat <<EOF
+Usage: ./scripts/build <command>
+
+Shortcuts:
+  debug      ./gradlew assembleDebug
+  release    ./gradlew assembleRelease
+  bundle     ./gradlew bundleRelease    (AAB for Play Store)
+  clean      ./gradlew clean
+  stop       ./gradlew --stop           (kill Gradle daemons)
+  version    ./gradlew --version
+
+Anything else is passed straight through to ./gradlew.
+EOF
+    exit 0
+    ;;
+  debug)    set -- assembleDebug ;;
+  release)  set -- assembleRelease ;;
+  bundle)   set -- bundleRelease ;;
+  clean)    set -- clean ;;
+  stop)     set -- --stop ;;
+  version)  set -- --version ;;
+esac
+
+exec ./gradlew "$@"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# One-shot dev environment bootstrap for bolt-nfc-android-app.
+# Installs SDKMAN (Java manager), nvm (Node manager), the pinned JDK and Node,
+# then yarn install. Idempotent — safe to re-run.
+#
+# Usage:
+#   ./scripts/setup.sh
+#
+# Requirements:
+#   - macOS or Linux
+#   - curl, bash, git
+#   - Android Studio + SDK installed separately (this script does NOT install Android SDK)
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_DIR"
+
+log()  { printf '\033[1;34m▸\033[0m %s\n' "$*"; }
+ok()   { printf '\033[1;32m✓\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m!\033[0m %s\n' "$*"; }
+err()  { printf '\033[1;31m✗\033[0m %s\n' "$*" >&2; }
+
+# -----------------------------------------------------------------------------
+# 1. SDKMAN — manages the Java toolchain via .sdkmanrc
+# -----------------------------------------------------------------------------
+if [ -d "${SDKMAN_DIR:-$HOME/.sdkman}" ]; then
+  ok "SDKMAN already installed at ${SDKMAN_DIR:-$HOME/.sdkman}"
+else
+  log "Installing SDKMAN…"
+  curl -s "https://get.sdkman.io?rcupdate=true" | bash
+  ok "SDKMAN installed. Restart your shell or run: source \"\$HOME/.sdkman/bin/sdkman-init.sh\""
+fi
+
+# shellcheck disable=SC1091
+source "${SDKMAN_DIR:-$HOME/.sdkman}/bin/sdkman-init.sh"
+
+# Enable auto-env so `cd` into the project switches Java automatically
+SDKMAN_CONFIG="${SDKMAN_DIR:-$HOME/.sdkman}/etc/config"
+if [ -f "$SDKMAN_CONFIG" ] && ! grep -q '^sdkman_auto_env=true' "$SDKMAN_CONFIG"; then
+  log "Enabling sdkman_auto_env in $SDKMAN_CONFIG"
+  if grep -q '^sdkman_auto_env=' "$SDKMAN_CONFIG"; then
+    sed -i.bak 's/^sdkman_auto_env=.*/sdkman_auto_env=true/' "$SDKMAN_CONFIG"
+  else
+    printf '\nsdkman_auto_env=true\n' >> "$SDKMAN_CONFIG"
+  fi
+fi
+
+log "Installing Java from .sdkmanrc (idempotent)…"
+sdk env install
+sdk env
+ok "Java: $(java -version 2>&1 | head -1)"
+
+# -----------------------------------------------------------------------------
+# 2. nvm — manages Node via .nvmrc
+# -----------------------------------------------------------------------------
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  ok "nvm already installed at $NVM_DIR"
+else
+  log "Installing nvm…"
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+fi
+# shellcheck disable=SC1091
+source "$NVM_DIR/nvm.sh"
+
+log "Installing Node from .nvmrc…"
+nvm install
+nvm use
+ok "Node: $(node --version)"
+
+# -----------------------------------------------------------------------------
+# 3. Yarn — install if missing (Corepack-friendly)
+# -----------------------------------------------------------------------------
+if ! command -v yarn >/dev/null 2>&1; then
+  log "Installing yarn…"
+  npm install -g yarn
+fi
+ok "Yarn: $(yarn --version)"
+
+# -----------------------------------------------------------------------------
+# 4. JS dependencies
+# -----------------------------------------------------------------------------
+log "Installing JS dependencies (yarn install)…"
+yarn install --frozen-lockfile
+ok "node_modules ready"
+
+# -----------------------------------------------------------------------------
+# 5. .env scaffold
+# -----------------------------------------------------------------------------
+if [ ! -f ".env" ]; then
+  if [ -f ".env-example" ]; then
+    log "Creating .env from .env-example — edit before building"
+    cp .env-example .env
+    warn "Update .env with your MIFARE_KEY and other secrets before deploying"
+  else
+    warn ".env not found and no .env-example to scaffold from"
+  fi
+else
+  ok ".env already present"
+fi
+
+# -----------------------------------------------------------------------------
+# 6. Android SDK sanity check
+# -----------------------------------------------------------------------------
+ANDROID_SDK="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-$HOME/Library/Android/sdk}}"
+if [ ! -d "$ANDROID_SDK" ]; then
+  warn "Android SDK not found at $ANDROID_SDK"
+  warn "Install Android Studio and the SDK, then set ANDROID_HOME, or edit android/local.properties"
+else
+  ok "Android SDK: $ANDROID_SDK"
+fi
+
+if [ ! -f "android/local.properties" ]; then
+  log "Creating android/local.properties pointing at $ANDROID_SDK"
+  printf 'sdk.dir=%s\n' "$ANDROID_SDK" > android/local.properties
+fi
+
+# -----------------------------------------------------------------------------
+# Done
+# -----------------------------------------------------------------------------
+ok "Setup complete."
+echo
+echo "Next steps:"
+echo "  1. Edit .env if you haven't already"
+echo "  2. yarn build:debug         # build debug APK"
+echo "  3. yarn android             # install on connected device/emulator"
+echo
+echo "If your shell hasn't loaded SDKMAN auto-env, run \`sdk env\` in this directory before building."

--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -1,0 +1,51 @@
+export interface DeviceJwtClaims {
+  userId: string;
+  pubkey: string;
+  role: string;
+  permissions: string[];
+  scopes: string[];
+  sub: string;
+  kind: 'device';
+  iss: string;
+  aud: string;
+  exp: number; // seconds since epoch
+  iat: number;
+}
+
+function base64urlDecode(str: string): string {
+  // Convert base64url → base64, then pad to a multiple of 4.
+  const b64 = str.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = b64.padEnd(b64.length + ((4 - (b64.length % 4)) % 4), '=');
+  return global.Buffer.from(padded, 'base64').toString('utf8');
+}
+
+export function isJwtFormat(token: string): boolean {
+  const parts = token.split('.');
+  return parts.length === 3 && parts.every(p => p.length > 0);
+}
+
+export function decodeJwt(token: string): DeviceJwtClaims | null {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+    const payload = JSON.parse(base64urlDecode(parts[1]));
+    if (typeof payload !== 'object' || payload === null) return null;
+    return payload as DeviceJwtClaims;
+  } catch {
+    return null;
+  }
+}
+
+// Returns true when the token is expired (or within skewSec of expiring).
+export function isExpired(
+  claims: DeviceJwtClaims | null,
+  skewSec: number = 30,
+): boolean {
+  if (!claims || typeof claims.exp !== 'number') return true;
+  return claims.exp * 1000 <= Date.now() + skewSec * 1000;
+}
+
+export function secondsUntilExpiry(claims: DeviceJwtClaims | null): number {
+  if (!claims || typeof claims.exp !== 'number') return 0;
+  return Math.max(0, Math.floor(claims.exp - Date.now() / 1000));
+}

--- a/src/lib/secureStorage.ts
+++ b/src/lib/secureStorage.ts
@@ -1,0 +1,24 @@
+import {NativeModules} from 'react-native';
+
+type SecureStorageNative = {
+  setItem(key: string, value: string): Promise<void>;
+  getItem(key: string): Promise<string | null>;
+  removeItem(key: string): Promise<void>;
+  clear(): Promise<void>;
+};
+
+const Native = NativeModules.SecureStorageModule as SecureStorageNative;
+
+export const STORAGE_KEYS = {
+  DEVICE_TOKEN: 'device_token',
+  BASE_URL: 'base_url',
+} as const;
+
+const SecureStorage = {
+  setItem: (key: string, value: string): Promise<void> => Native.setItem(key, value),
+  getItem: (key: string): Promise<string | null> => Native.getItem(key),
+  removeItem: (key: string): Promise<void> => Native.removeItem(key),
+  clear: (): Promise<void> => Native.clear(),
+};
+
+export default SecureStorage;

--- a/src/providers/LaWallet.tsx
+++ b/src/providers/LaWallet.tsx
@@ -1,82 +1,293 @@
-import React, {createContext, useContext, useState} from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {Skin} from '../types/skin';
+import {CardDesign} from '../types/response';
 import {skins as skinsFile} from '../constants/skins';
-import {LoginResponse} from '../types/response';
+import {decodeJwt, isExpired, isJwtFormat} from '../lib/jwt';
+import type {DeviceJwtClaims} from '../lib/jwt';
+import SecureStorage, {STORAGE_KEYS} from '../lib/secureStorage';
 
-const LaWalletContext = createContext<{
+export class AuthError extends Error {
+  kind: 'no-token' | 'expired';
+  constructor(kind: 'no-token' | 'expired') {
+    super(kind === 'expired' ? 'Session token expired' : 'No auth token');
+    this.kind = kind;
+  }
+}
+
+function normalizeBaseUrl(url: string): string {
+  let u = url.trim();
+  if (!u) return '';
+  if (!u.startsWith('http://') && !u.startsWith('https://')) {
+    u = 'https://' + u;
+  }
+  return u.replace(/\/+$/, '');
+}
+
+function extractHost(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url.replace(/^https?:\/\//, '').split('/')[0];
+  }
+}
+
+interface LaWalletContextType {
   isLogged: boolean;
-  login: (apiEndpoint: string) => Promise<void>;
-  logout: () => void;
   isLoading: boolean;
-  apiEndpoint: string;
+  baseUrl: string;
+  jwt: string | null;
+  claims: DeviceJwtClaims | null;
+  pubkey: string | null;
+  scopes: string[];
+  exp: number | null;
+  tokenError: 'expired' | 'invalid' | null;
   skins: Skin[];
   lnurlwBase: string;
-}>({
+  setBaseUrl: (url: string) => Promise<void>;
+  loginWithToken: (
+    token: string,
+  ) => Promise<{ok: boolean; reason?: 'invalid' | 'expired'}>;
+  logout: () => Promise<void>;
+  authFetch: (path: string, init?: RequestInit) => Promise<Response>;
+  fetchDesigns: () => Promise<void>;
+  hasScope: (scope: string) => boolean;
+}
+
+const LaWalletContext = createContext<LaWalletContextType>({
   isLogged: false,
-  login: async () => {},
-  logout: () => {},
-  isLoading: false,
-  apiEndpoint: '',
-  skins: [],
+  isLoading: true,
+  baseUrl: '',
+  jwt: null,
+  claims: null,
+  pubkey: null,
+  scopes: [],
+  exp: null,
+  tokenError: null,
+  skins: skinsFile,
   lnurlwBase: '',
+  setBaseUrl: async () => {},
+  loginWithToken: async () => ({ok: false, reason: 'invalid'}),
+  logout: async () => {},
+  authFetch: async () => {
+    throw new AuthError('no-token');
+  },
+  fetchDesigns: async () => {},
+  hasScope: () => false,
 });
 
-export const LaWalletProvider = ({children}) => {
-  const [isLogged, setIsLogged] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const [apiEndpoint, setApiEndpoint] = useState('');
-  const [skins, setSkins] = useState<Skin[]>([]);
-  const [lnurlwBase, setLnurlwBase] = useState<string>('');
+export const LaWalletProvider = ({children}: {children: React.ReactNode}) => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [baseUrl, setBaseUrlSt] = useState('');
+  const [jwt, setJwtSt] = useState<string | null>(null);
+  const [claims, setClaimsSt] = useState<DeviceJwtClaims | null>(null);
+  const [tokenError, setTokenError] = useState<'expired' | 'invalid' | null>(
+    null,
+  );
+  const [skins, setSkins] = useState<Skin[]>(skinsFile);
 
-  const login = async (_apiEndpoint: string) => {
-    setIsLoading(true);
+  // Refs keep the latest values accessible in stable callbacks without
+  // recreating them on every state change.
+  const jwtRef = useRef<string | null>(null);
+  const baseUrlRef = useRef<string>('');
+  const claimsRef = useRef<DeviceJwtClaims | null>(null);
 
-    try {
-      const {skins: _skins, lnurlwBase: _lnurlwBase} = await mockEndpoint();
-      setApiEndpoint(_apiEndpoint);
-      setSkins(_skins);
-      setLnurlwBase(_lnurlwBase);
-      setIsLogged(true);
-    } catch (error) {
-      logout();
-      console.error(error);
-    } finally {
-      setIsLoading(false);
+  // Helpers that keep refs and state in sync.
+  const applyJwt = useCallback(
+    (token: string | null, decoded: DeviceJwtClaims | null) => {
+      jwtRef.current = token;
+      claimsRef.current = decoded;
+      setJwtSt(token);
+      setClaimsSt(decoded);
+    },
+    [],
+  );
+
+  const applyBaseUrl = useCallback((url: string) => {
+    baseUrlRef.current = url;
+    setBaseUrlSt(url);
+  }, []);
+
+  // Hydrate from secure storage on mount.
+  useEffect(() => {
+    (async () => {
+      try {
+        const [storedUrl, storedToken] = await Promise.all([
+          SecureStorage.getItem(STORAGE_KEYS.BASE_URL),
+          SecureStorage.getItem(STORAGE_KEYS.DEVICE_TOKEN),
+        ]);
+        if (storedUrl) applyBaseUrl(storedUrl);
+        if (storedToken) {
+          const decoded = decodeJwt(storedToken);
+          if (decoded && !isExpired(decoded)) {
+            applyJwt(storedToken, decoded);
+          } else {
+            // Keep the base URL but drop the stale token.
+            await SecureStorage.removeItem(STORAGE_KEYS.DEVICE_TOKEN);
+            if (storedToken) setTokenError('expired');
+          }
+        }
+      } catch (e) {
+        console.error('LaWallet: hydration error', e);
+      } finally {
+        setIsLoading(false);
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Stable authenticated fetch — reads from refs so it never goes stale.
+  const authFetch = useCallback(
+    async (path: string, init: RequestInit = {}): Promise<Response> => {
+      const token = jwtRef.current;
+      if (!token) throw new AuthError('no-token');
+      const url = baseUrlRef.current + path;
+      const mergedHeaders: Record<string, string> = {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        ...((init.headers as Record<string, string>) || {}),
+      };
+      const res = await fetch(url, {...init, headers: mergedHeaders});
+      if (res.status === 401) {
+        jwtRef.current = null;
+        claimsRef.current = null;
+        setJwtSt(null);
+        setClaimsSt(null);
+        setTokenError('expired');
+        SecureStorage.removeItem(STORAGE_KEYS.DEVICE_TOKEN).catch(() => {});
+        throw new AuthError('expired');
+      }
+      return res;
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  // Fetch designs from the API, falling back to the hardcoded list on any error.
+  const fetchDesigns = useCallback(async () => {
+    const currentScopes = claimsRef.current?.scopes ?? [];
+    if (!currentScopes.includes('card_designs:read')) {
+      setSkins(skinsFile);
+      return;
     }
-  };
+    try {
+      const res = await authFetch('/api/card-designs/list');
+      if (res.ok) {
+        const designs: CardDesign[] = await res.json();
+        const mapped: Skin[] = designs
+          .filter(d => !d.archivedAt)
+          .map(d => ({label: d.description, value: d.id, file: d.imageUrl}));
+        setSkins(mapped.length > 0 ? mapped : skinsFile);
+      } else {
+        setSkins(skinsFile);
+      }
+    } catch {
+      setSkins(skinsFile);
+    }
+  }, [authFetch]);
 
-  const logout = () => {
-    setIsLogged(false);
-    setApiEndpoint('');
-    setLnurlwBase('');
-    setSkins([]);
-  };
+  const setBaseUrl = useCallback(
+    async (url: string) => {
+      const normalized = normalizeBaseUrl(url);
+      applyBaseUrl(normalized);
+      if (normalized) {
+        await SecureStorage.setItem(STORAGE_KEYS.BASE_URL, normalized);
+      }
+    },
+    [applyBaseUrl],
+  );
+
+  const loginWithToken = useCallback(
+    async (
+      token: string,
+    ): Promise<{ok: boolean; reason?: 'invalid' | 'expired'}> => {
+      if (!isJwtFormat(token)) return {ok: false, reason: 'invalid'};
+      const decoded = decodeJwt(token);
+      if (!decoded) return {ok: false, reason: 'invalid'};
+      if (isExpired(decoded)) return {ok: false, reason: 'expired'};
+
+      // Update refs first so authFetch (used by fetchDesigns) sees the new token.
+      applyJwt(token, decoded);
+      setTokenError(null);
+      SecureStorage.setItem(STORAGE_KEYS.DEVICE_TOKEN, token).catch(() => {});
+
+      // Non-blocking; refs are already updated so authFetch has the right token.
+      fetchDesigns().catch(() => {});
+
+      return {ok: true};
+    },
+    [applyJwt, fetchDesigns],
+  );
+
+  const logout = useCallback(async () => {
+    applyJwt(null, null);
+    setTokenError(null);
+    setSkins(skinsFile);
+    await SecureStorage.removeItem(STORAGE_KEYS.DEVICE_TOKEN).catch(() => {});
+    // Keep baseUrl persisted so the operator doesn't have to re-enter it.
+  }, [applyJwt]);
+
+  const hasScope = useCallback(
+    (scope: string): boolean => (claims?.scopes ?? []).includes(scope),
+    [claims],
+  );
+
+  const isLogged = !!jwt && !isExpired(claims);
+  const pubkey = claims?.pubkey ?? null;
+  const scopes = claims?.scopes ?? [];
+  const exp = claims?.exp ?? null;
+  const lnurlwBase = baseUrl ? `lnurlw://${extractHost(baseUrl)}` : '';
+
+  const value = useMemo<LaWalletContextType>(
+    () => ({
+      isLogged,
+      isLoading,
+      baseUrl,
+      jwt,
+      claims,
+      pubkey,
+      scopes,
+      exp,
+      tokenError,
+      skins,
+      lnurlwBase,
+      setBaseUrl,
+      loginWithToken,
+      logout,
+      authFetch,
+      fetchDesigns,
+      hasScope,
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      isLogged,
+      isLoading,
+      baseUrl,
+      jwt,
+      claims,
+      tokenError,
+      skins,
+      setBaseUrl,
+      loginWithToken,
+      logout,
+      authFetch,
+      fetchDesigns,
+      hasScope,
+    ],
+  );
 
   return (
-    <LaWalletContext.Provider
-      value={{
-        isLogged,
-        login,
-        logout,
-        isLoading,
-        apiEndpoint,
-        skins,
-        lnurlwBase,
-      }}>
+    <LaWalletContext.Provider value={value}>
       {children}
     </LaWalletContext.Provider>
   );
 };
-
-async function mockEndpoint(): Promise<LoginResponse> {
-  return new Promise((resolve: (value: LoginResponse) => void) => {
-    setTimeout(() => {
-      resolve({
-        skins: skinsFile,
-        lnurlwBase: 'https://lnurlw.ar',
-      });
-    }, 1000);
-  });
-}
 
 export const useLaWallet = () => useContext(LaWalletContext);

--- a/src/screens/CreateBulkBoltcardScreen.tsx
+++ b/src/screens/CreateBulkBoltcardScreen.tsx
@@ -17,8 +17,8 @@ import {Card, Title} from 'react-native-paper';
 import NfcManager, {NfcTech} from 'react-native-nfc-manager';
 import WriteModal from '../components/WriteModal';
 
-import {useLaWallet} from '../providers/LaWallet';
-import {InitializeCardResponse} from '../types/response';
+import {useLaWallet, AuthError} from '../providers/LaWallet';
+import {Ntag424WriteData} from '../types/response';
 import {Skin} from '../types/skin';
 
 const CardStatus = {
@@ -29,7 +29,7 @@ const CardStatus = {
 };
 
 export default function CreateBulkBoltcardScreen() {
-  const [cardData, setCardData] = useState<InitializeCardResponse>();
+  const [cardData, setCardData] = useState<Ntag424WriteData | undefined>();
 
   const [cardStatus, setCardStatus] = useState(CardStatus.IDLE);
 
@@ -38,69 +38,98 @@ export default function CreateBulkBoltcardScreen() {
   const [error, setError] = useState<string>();
 
   const navigation = useNavigation();
-  const {isLogged, skins, lnurlwBase, apiEndpoint} = useLaWallet();
+  const {isLogged, skins, authFetch, baseUrl} = useLaWallet();
 
   const requestCreateCard = useCallback(
-    async (_cardUID, _skin) => {
+    async (_cardUID: string, _skin: Skin) => {
       setCardStatus(CardStatus.CREATING_CARD);
-      // Make request to create card
+      setError(undefined);
 
-      const url = `${apiEndpoint}`;
-      // console.info('url', url);
-      // create request
       ToastAndroid.showWithGravity(
-        `Creating card : ${url}`,
+        'Creating card…',
         ToastAndroid.SHORT,
         ToastAndroid.TOP,
       );
 
-      const body = {
-        designId: _skin.value,
-        cardUID: _cardUID,
-      };
-
-      // console.info('skin', _skin);
-      // console.info('cardUID', _cardUID);
-
-      // console.info('event');
-      // console.info(JSON.stringify(event));
-      fetch(url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(body),
-      })
-        .then(response => {
-          // console.info('response', JSON.stringify(response));
-
-          if (!response.ok) {
-            throw new Error(`Server returned error ${response.status}`);
-          }
-          return response.json();
-        })
-        .then(json => {
-          const data = JSON.parse(json.content) as InitializeCardResponse;
-          if (!(data.k0 && data.k1 && data.k2 && data.k3 && data.k4)) {
-            setCardStatus(CardStatus.IDLE);
-            alert('The JSON response must contain k0, k1, k2, k3, k4');
-            return;
-          }
-          setCardStatus(CardStatus.WRITING);
-          setCardData(data);
-        })
-        .catch(_error => {
-          setError(JSON.stringify(_error));
-          alert(_error.message);
-          setCardStatus(CardStatus.IDLE);
-          console.error(_error);
+      try {
+        // 1. Create the card on the backend (auth-gated: cards:write scope).
+        const createRes = await authFetch('/api/cards', {
+          method: 'POST',
+          body: JSON.stringify({
+            id: _cardUID,
+            designId: _skin.value,
+            kind: 'SIMPLE',
+          }),
         });
+
+        if (!createRes.ok) {
+          const msg = await createRes.text().catch(() => '');
+          alert(`Server error ${createRes.status}: ${msg}`);
+          setCardStatus(CardStatus.IDLE);
+          return;
+        }
+
+        const createdCard = await createRes.json();
+        const cardId: string = createdCard.id;
+
+        // 2. Fetch the canonical write payload (public endpoint — no auth needed).
+        //    It includes the lnurlw_base and keys already assembled by the server.
+        let writeData: Ntag424WriteData;
+        try {
+          const writeRes = await fetch(`${baseUrl}/api/cards/${cardId}/write`);
+          if (writeRes.ok) {
+            writeData = await writeRes.json();
+          } else {
+            throw new Error(`write endpoint returned ${writeRes.status}`);
+          }
+        } catch (writeErr) {
+          // Fallback: build the payload from the POST response keys.
+          console.warn('CreateBulk: write endpoint failed, using POST keys', writeErr);
+          const ntag = createdCard.ntag424;
+          const host = (() => {
+            try {
+              return new URL(baseUrl).host;
+            } catch {
+              return baseUrl.replace(/^https?:\/\//, '').split('/')[0];
+            }
+          })();
+          writeData = {
+            card_name: createdCard.title || 'New Card',
+            id: ntag.cid,
+            k0: ntag.k0,
+            k1: ntag.k1,
+            k2: ntag.k2,
+            k3: ntag.k3,
+            k4: ntag.k4,
+            lnurlw_base: `lnurlw://${host}/api/cards/${cardId}/scan`,
+            protocol_name: 'new_bolt_card_response',
+            protocol_version: '1',
+          };
+        }
+
+        setCardData(writeData);
+        setCardStatus(CardStatus.WRITING);
+      } catch (err) {
+        if (err instanceof AuthError && err.kind === 'expired') {
+          ToastAndroid.showWithGravity(
+            'Session expired — re-login on the Login tab',
+            ToastAndroid.LONG,
+            ToastAndroid.TOP,
+          );
+        } else {
+          const msg =
+            err instanceof Error ? err.message : JSON.stringify(err);
+          setError(msg);
+          alert(msg);
+        }
+        setCardStatus(CardStatus.IDLE);
+      }
     },
-    [apiEndpoint, setCardStatus, setCardData, setError],
+    [authFetch, baseUrl],
   );
 
   const onReadCard = useCallback(
-    event => {
+    (event: any) => {
       const _cardUID = event.id?.toLowerCase();
       console.log(
         event.key0Changed,
@@ -120,8 +149,8 @@ export default function CreateBulkBoltcardScreen() {
       }
 
       try {
-        requestCreateCard(_cardUID, skin);
-      } catch (e) {
+        requestCreateCard(_cardUID, skin!);
+      } catch (e: any) {
         alert(e.reason);
         setCardStatus(CardStatus.IDLE);
       }
@@ -137,10 +166,8 @@ export default function CreateBulkBoltcardScreen() {
       console.info('START reading...');
       await NfcManager.requestTechnology(NfcTech.IsoDep);
       const tag = await NfcManager.getTag();
-
-      // console.info('tag:');
       onReadCard(tag);
-    } catch (e) {
+    } catch (e: any) {
       setCardStatus(CardStatus.IDLE);
       alert(e?.message);
       console.error(e?.message);
@@ -150,15 +177,13 @@ export default function CreateBulkBoltcardScreen() {
   // On exit screen
   useEffect(() => {
     const unsubscribe = navigation.addListener('blur', () => {
-      // Do something when the screen blurs
       setCardStatus(CardStatus.IDLE);
       NfcManager.cancelTechnologyRequest();
     });
-
     return unsubscribe;
   }, [navigation]);
 
-  // Add Listeners
+  // React to cardStatus changes
   useEffect(() => {
     switch (cardStatus) {
       case CardStatus.READING:
@@ -166,22 +191,11 @@ export default function CreateBulkBoltcardScreen() {
         setCardData(undefined);
         startReading();
         break;
-
       default:
         setCardData(undefined);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cardStatus]);
-
-  // On mount
-  useEffect(() => {
-    // NfcManager.start();
-    // console.info('getPublicKey');
-    // console.info(getPublicKey);
-    // const pubkey = getPublicKey(NOSTR_PRIVATE_KEY);
-    // console.info('pubkey');
-    // console.info(pubkey);
-  }, []);
 
   if (!isLogged) {
     return (
@@ -193,7 +207,7 @@ export default function CreateBulkBoltcardScreen() {
           zIndex: 1000,
         }}>
         <Card.Content>
-          <Text>Not logged in</Text>
+          <Text>Not logged in — go to the Login tab to authenticate.</Text>
         </Card.Content>
       </Card>
     );
@@ -304,7 +318,7 @@ export default function CreateBulkBoltcardScreen() {
         visible={cardStatus === CardStatus.WRITING}
         onCancel={() => setCardStatus(CardStatus.IDLE)}
         onSuccess={() => setCardStatus(CardStatus.READING)}
-        cardData={{...cardData, lnurlw_base: lnurlwBase}}
+        cardData={cardData}
       />
     </ScrollView>
   );

--- a/src/screens/Login.tsx
+++ b/src/screens/Login.tsx
@@ -1,114 +1,270 @@
 /* eslint-disable react-native/no-inline-styles */
-import React, {useEffect} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {useNavigation} from '@react-navigation/native';
 import {
-  TouchableOpacity,
+  Alert,
   ScrollView,
   StyleSheet,
   Text,
+  TextInput,
+  TouchableOpacity,
   View,
 } from 'react-native';
 import {Card, Title} from 'react-native-paper';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import {useLaWallet} from '../providers/LaWallet';
+import {secondsUntilExpiry} from '../lib/jwt';
+
+function formatCountdown(secs: number): string {
+  if (secs <= 0) return 'expired';
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  const s = secs % 60;
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
 
 export default function LoginScreen({route}) {
-  const {login, isLogged, isLoading, logout} = useLaWallet();
-  // get data from QR
-  const {data: qrData, timestamp} = route.params || {};
-  // use navigation
+  const {
+    baseUrl,
+    setBaseUrl,
+    loginWithToken,
+    logout,
+    isLogged,
+    isLoading,
+    pubkey,
+    scopes,
+    claims,
+    tokenError,
+  } = useLaWallet();
+
   const navigation = useNavigation();
 
-  const handleLogin = () => {
-    // login('holaaa');
-    (navigation as any).navigate('ScanScreenLogin', {
-      backScreen: 'LoginScreen',
-    });
-  };
+  // Local state for the base URL text input (not persisted until Save).
+  const [urlInput, setUrlInput] = useState(baseUrl);
+  const [countdown, setCountdown] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const handleLogout = () => {
-    logout();
-  };
-
+  // Sync text input when baseUrl changes (e.g. on hydration).
   useEffect(() => {
-    if (!qrData || !timestamp) {
+    setUrlInput(baseUrl);
+  }, [baseUrl]);
+
+  // Expiry countdown ticker.
+  useEffect(() => {
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    if (!isLogged || !claims) {
+      setCountdown(0);
       return;
     }
-    login(qrData.url);
+    setCountdown(secondsUntilExpiry(claims));
+    intervalRef.current = setInterval(() => {
+      setCountdown(secondsUntilExpiry(claims));
+    }, 1000);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [isLogged, claims]);
+
+  // Receive QR scan result and attempt login.
+  const {data: qrData, timestamp} = route.params || {};
+  useEffect(() => {
+    if (!qrData?.raw || !timestamp) return;
+    (async () => {
+      const res = await loginWithToken(qrData.raw);
+      if (!res.ok) {
+        Alert.alert(
+          'Login failed',
+          res.reason === 'expired'
+            ? 'Token is already expired — ask the admin for a fresh QR.'
+            : 'That QR is not a valid device token.',
+        );
+      }
+    })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [qrData, timestamp]);
 
+  const handleScan = useCallback(() => {
+    (navigation as any).navigate('ScanScreenLogin', {
+      backScreen: 'LoginScreen',
+      mode: 'raw',
+    });
+  }, [navigation]);
+
+  const handleSaveUrl = useCallback(async () => {
+    await setBaseUrl(urlInput);
+  }, [setBaseUrl, urlInput]);
+
+  const handleLogout = useCallback(() => logout(), [logout]);
+
+  const shortPubkey = pubkey
+    ? `${pubkey.slice(0, 8)}…${pubkey.slice(-4)}`
+    : '';
+
   return (
-    <>
-      <ScrollView>
-        <Card style={{marginBottom: 20, marginHorizontal: 10}}>
-          <Card.Content>
-            <Title>Login to LaWallet</Title>
-            <Text>{isLogged ? 'Logged in' : 'Not logged in'}</Text>
-          </Card.Content>
-        </Card>
-        <Card style={{marginBottom: 20, marginHorizontal: 10}}>
-          <Card.Content>
-            <View
-              style={{flexDirection: 'row', justifyContent: 'space-evenly'}}>
-              {isLoading ? (
-                <Text>Logging in...</Text>
-              ) : isLogged ? (
-                <TouchableOpacity
-                  style={styles.button}
-                  onPress={() => handleLogout()}>
-                  <Text style={styles.buttonText}>
-                    <Ionicons name="log-out" size={20} color="white" /> Logout
-                  </Text>
-                </TouchableOpacity>
-              ) : (
-                <TouchableOpacity
-                  style={styles.button}
-                  onPress={() => handleLogin()}>
-                  <Text style={styles.buttonText}>
-                    <Ionicons name="log-in" size={20} color="white" /> Login to
-                    LaWallet
-                  </Text>
-                </TouchableOpacity>
-              )}
+    <ScrollView>
+      {/* Base URL configuration */}
+      <Card style={styles.card}>
+        <Card.Content>
+          <Title>LaWallet backend</Title>
+          <Text style={styles.label}>Base URL</Text>
+          <View style={styles.row}>
+            <TextInput
+              style={styles.urlInput}
+              value={urlInput}
+              onChangeText={setUrlInput}
+              placeholder="https://app.lawallet.ar"
+              autoCapitalize="none"
+              autoCorrect={false}
+              keyboardType="url"
+            />
+            <TouchableOpacity style={styles.saveBtn} onPress={handleSaveUrl}>
+              <Text style={styles.saveBtnText}>Save</Text>
+            </TouchableOpacity>
+          </View>
+        </Card.Content>
+      </Card>
+
+      {/* Auth status */}
+      <Card style={styles.card}>
+        <Card.Content>
+          <Title>Session</Title>
+
+          {/* Expired banner */}
+          {tokenError === 'expired' && !isLogged && (
+            <View style={styles.banner}>
+              <Ionicons name="warning" size={16} color="#fff" />
+              <Text style={styles.bannerText}>
+                {' '}Session expired — scan a new token
+              </Text>
             </View>
-          </Card.Content>
-        </Card>
-      </ScrollView>
-    </>
+          )}
+
+          {isLoading ? (
+            <Text>Loading…</Text>
+          ) : isLogged ? (
+            <>
+              <View style={styles.infoRow}>
+                <Ionicons name="checkmark-circle" size={18} color="green" />
+                <Text style={styles.infoText}> Logged in</Text>
+              </View>
+              <Text style={styles.detail}>Pubkey: {shortPubkey}</Text>
+              <Text style={styles.detail}>Scopes: {scopes.join(', ') || '—'}</Text>
+              <Text style={styles.detail}>
+                Expires in: {formatCountdown(countdown)}
+              </Text>
+              <TouchableOpacity style={styles.button} onPress={handleLogout}>
+                <Text style={styles.buttonText}>
+                  <Ionicons name="log-out" size={18} color="white" /> Logout
+                </Text>
+              </TouchableOpacity>
+            </>
+          ) : (
+            <>
+              <Text style={styles.detail}>Not logged in</Text>
+              <TouchableOpacity
+                style={[styles.button, !baseUrl && styles.buttonDisabled]}
+                onPress={handleScan}
+                disabled={!baseUrl}>
+                <Text style={styles.buttonText}>
+                  <Ionicons name="qr-code" size={18} color="white" /> Scan device token
+                </Text>
+              </TouchableOpacity>
+              {!baseUrl && (
+                <Text style={styles.hint}>Set the base URL above first.</Text>
+              )}
+            </>
+          )}
+        </Card.Content>
+      </Card>
+    </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
-  button: {
-    backgroundColor: 'rgb(0,122,255)',
-    padding: 5,
+  card: {
+    marginBottom: 12,
+    marginTop: 10,
+    marginHorizontal: 10,
+  },
+  label: {
+    fontSize: 13,
+    color: '#555',
+    marginBottom: 4,
+    marginTop: 8,
+  },
+  row: {
     flexDirection: 'row',
-    alignSelf: 'flex-start',
+    alignItems: 'center',
+    gap: 8,
+  },
+  urlInput: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    fontSize: 14,
+  },
+  saveBtn: {
+    backgroundColor: '#555',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 6,
+  },
+  saveBtnText: {
+    color: '#fff',
+    fontWeight: 'bold',
+    fontSize: 13,
+  },
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#c0392b',
+    borderRadius: 6,
+    padding: 8,
     marginBottom: 10,
   },
+  bannerText: {
+    color: '#fff',
+    fontWeight: 'bold',
+  },
+  infoRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 6,
+  },
+  infoText: {
+    fontSize: 15,
+    fontWeight: 'bold',
+    color: '#222',
+  },
+  detail: {
+    fontSize: 13,
+    color: '#444',
+    marginBottom: 4,
+  },
+  hint: {
+    fontSize: 12,
+    color: '#888',
+    marginTop: 6,
+  },
+  button: {
+    backgroundColor: 'rgb(0,122,255)',
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 6,
+    alignSelf: 'flex-start',
+    marginTop: 10,
+  },
+  buttonDisabled: {
+    backgroundColor: '#aaa',
+  },
   buttonText: {
-    textTransform: 'uppercase',
     color: 'white',
     fontWeight: 'bold',
-    flexDirection: 'row',
-    fontSize: 15,
-  },
-  centerText: {
-    flex: 1,
-    fontSize: 18,
-    padding: 32,
-    color: '#777',
-  },
-  textBold: {
-    fontWeight: '500',
-    color: '#000',
-  },
-
-  buttonTouchable: {
-    padding: 16,
-  },
-  paragraph: {
-    marginBottom: 20,
+    fontSize: 14,
   },
 });

--- a/src/screens/ResetKeysScreen.js
+++ b/src/screens/ResetKeysScreen.js
@@ -173,7 +173,7 @@ export default function ResetKeysScreen({route}) {
   };
 
   const scanQRCode = () => {
-    navigation.navigate('ScanScreen', {
+    navigation.navigate('ScanScreenReset', {
       backRoot: 'Advanced',
       backScreen: 'ResetKeysScreen',
     });

--- a/src/screens/ScanScreen.js
+++ b/src/screens/ScanScreen.js
@@ -12,9 +12,10 @@ export default function ScanScreen({route, navigation}) {
   const devices = useCameraDevices();
   const device = devices.back;
 
-  const {backScreen, credentials} = route.params;
+  // mode:'raw' passes the QR value straight through (used for JWT login).
+  // mode:'url' (default) extracts the 'c' query param (legacy flow).
+  const {backScreen, credentials, mode = 'url'} = route.params || {};
 
-  // console.log('Scan Screen backScreen, backRoot', backScreen, backRoot);
   const [frameProcessor, barcodes] = useScanBarcodes([BarcodeFormat.QR_CODE], {
     checkInverted: true,
   });
@@ -28,15 +29,22 @@ export default function ScanScreen({route, navigation}) {
 
   const onSuccess = data => {
     console.log('scan success');
-    const cardNonce = getQueryParam(data, 'c');
-    const url = data;
-    navigation.navigate(backScreen, {
-      data: {otc: cardNonce, url, credentials},
-      timestamp: Date.now(),
-    });
+    if (mode === 'raw') {
+      navigation.navigate(backScreen, {
+        data: {raw: data},
+        timestamp: Date.now(),
+      });
+    } else {
+      const cardNonce = getQueryParam(data, 'c');
+      const url = data;
+      navigation.navigate(backScreen, {
+        data: {otc: cardNonce, url, credentials},
+        timestamp: Date.now(),
+      });
+    }
   };
 
-  const goBack = e => {
+  const goBack = () => {
     navigation.navigate(backScreen);
   };
 
@@ -57,7 +65,11 @@ export default function ScanScreen({route, navigation}) {
         />
         <Button
           onPress={() =>
-            onSuccess('https://app.lawallet.ar/start?i=987654321&c=12345678')
+            mode === 'raw'
+              ? onSuccess('eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiJ0ZXN0IiwicHViY2V5IjoiYWJjZCIsInJvbGUiOiJBRE1JTiIsInBlcm1pc3Npb25zIjpbImNhcmRzOndyaXRlIl0sInNjb3BlcyI6WyJjYXJkczp3cml0ZSJdLCJzdWIiOiJ0ZXN0IiwiaXNzIjoibGF3YWxsZXQtbndlIiwiYXVkIjoibGF3YWxsZXQtdXNlcnMiLCJleHAiOjk5OTk5OTk5OTl9.abc')
+              : onSuccess(
+                  'https://app.lawallet.ar/start?i=987654321&c=12345678',
+                )
           }
           title="Test"
         />

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -11,5 +11,50 @@ export type InitializeCardResponse = {
   k2: string;
   k3: string;
   k4: string;
-  privateUID: string;
+  privateUID?: string;
+};
+
+export type CardDesign = {
+  id: string;
+  imageUrl: string;
+  description: string;
+  createdAt: string;
+  archivedAt?: string | null;
+};
+
+export type Ntag424Keys = {
+  cid: string;
+  k0: string;
+  k1: string;
+  k2: string;
+  k3: string;
+  k4: string;
+  ctr: number;
+  createdAt: string;
+};
+
+export type Card = {
+  id: string; // server-generated hex id (NOT the chip uid)
+  design: {id: string; imageUrl: string; description: string; createdAt: string};
+  ntag424: Ntag424Keys;
+  createdAt: string;
+  title?: string;
+  lastUsedAt?: string;
+  pubkey?: string;
+  username?: string;
+  otc?: string;
+  kind: string;
+};
+
+export type Ntag424WriteData = {
+  card_name: string;
+  id: string;
+  k0: string;
+  k1: string;
+  k2: string;
+  k3: string;
+  k4: string;
+  lnurlw_base: string; // lnurlw://<host>/api/cards/<id>/scan
+  protocol_name: 'new_bolt_card_response';
+  protocol_version: '1';
 };


### PR DESCRIPTION
## Summary

Implements issue #4: field operators scan a QR-JWT device token to log in, then create and write NTAG424 cards against a LaWallet NWC instance ([backend: lawalletio/lawallet-nwc#1](https://github.com/lawalletio/lawallet-nwc/pull/1)).

### What changed

**Android (requires a clean gradle rebuild)**
- **`SecureStorageModule.java`** (new) — Android Keystore-backed `EncryptedSharedPreferences` for storing the JWT + base URL. Handles Keystore corruption gracefully (auto-clears store, forces re-login, never crashes the bridge). Registered in `MyReactPackage`.
- `minSdkVersion` bumped **21 → 23** (required by `androidx.security:security-crypto`; Android 5.x share is negligible in 2026).
- `compileSdkVersion` / `targetSdkVersion` bumped **31 → 33**.
- Added `androidx.security:security-crypto:1.1.0-alpha06` dependency.

**New JS/TS files**
- `src/lib/secureStorage.ts` — typed `NativeModules.SecureStorageModule` wrapper with `STORAGE_KEYS`.
- `src/lib/jwt.ts` — `decodeJwt`, `isJwtFormat`, `isExpired`, `secondsUntilExpiry`, `DeviceJwtClaims`. No external deps; uses the existing `global.Buffer` shim.
- `src/types/response.ts` — added `Card`, `CardDesign`, `Ntag424Keys`, `Ntag424WriteData`.

**Provider rewrite (`src/providers/LaWallet.tsx`)**
- Replaces the `mockEndpoint` with real auth state and API calls.
- Hydrates `jwt` + `baseUrl` from secure storage on mount; drops expired tokens silently.
- Stable `authFetch` (reads refs, attaches `Authorization: Bearer`, handles `401` → sets `tokenError='expired'`, clears token, throws `AuthError`).
- `loginWithToken(jwt)` — validates JWT format + expiry client-side before persisting.
- `fetchDesigns()` — calls `GET /api/card-designs/list` (scope `card_designs:read`); falls back to hardcoded skins on error or missing scope.
- `setBaseUrl`, `logout`, `hasScope`.

**Screens**
- `ScanScreen.js` — added `mode='raw'` param that passes the QR value straight through (JWT login path); fixed a no-params crash guard.
- `Login.tsx` — rebuilt: base URL input + Save, Scan device token button (`mode:'raw'`), logged-in panel with short pubkey / scopes / live expiry countdown, expired-session banner, Logout.
- `CreateBulkBoltcardScreen.tsx` — replaces the old Nostr/`json.content` parse with `POST /api/cards → GET /api/cards/<id>/write` flow; falls back to POST-returned keys if the write endpoint fails; catches `AuthError` with a Toast.
- `ResetKeysScreen.js` — fixes a pre-existing route-name typo (`'ScanScreen'` → `'ScanScreenReset'`) that caused a navigation crash.

**Toolchain (pre-existing local changes included)**
- `scripts/setup.sh`, `scripts/build`, `.sdkmanrc`; updated `README.md` + `package.json`.

### Backend contract

| Endpoint | Auth | Notes |
|---|---|---|
| `POST /api/cards` `{id, designId, kind?}` | Bearer `cards:write` | `id` = chip NFC UID; returns full card with `ntag424.{k0..k4}` |
| `GET /api/cards/<id>/write` | **public** | Returns canonical `Ntag424WriteData` with `lnurlw_base` |
| `GET /api/card-designs/list` | Bearer `card_designs:read` | Design picker; falls back to hardcoded list |

### Key decisions

- **QR payload = raw JWT string** (no URL wrapper); base URL is entered separately and persisted.
- **`privateUID` intentionally omitted** — it's a feature flag for `Ntag424.setPrivateUid()`; leaving it `undefined` preserves the existing off-by-default behaviour.
- **Write endpoint preferred over assembling `lnurlw_base` locally** — the server may use a different public host than the API base.

## Test plan

- [ ] Android builds cleanly after `yarn clean:full && yarn android` (new AAR + minSdk + native module).
- [ ] On device: set base URL → scan a real device-token QR → logged-in panel shows pubkey, scopes, expiry countdown.
- [ ] Kill & relaunch → stays logged in (token persisted). Let it expire → expired banner, re-scan works.
- [ ] 401 mid-provisioning → Toast "Session expired" + re-login required.
- [ ] Select skin → tap blank NTAG424 → card created → chip programmed → `WriteModal` shows all keys "Written".
- [ ] Designs dropdown populated from API when `card_designs:read` scope present; falls back to hardcoded list otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)