### PR TITLE
feat: tap-to-wipe flow, instance-aware login, and NFC UX overhaul

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,5 @@
 import React, {useEffect, useState} from 'react';
+import {useLaWallet} from './src/providers/LaWallet';
 import {
   Image,
   Modal,
@@ -24,7 +25,7 @@ import LinkCardQRScreen from './src/screens/LinkCardQRScreen';
 import CreateBulkBoltcardScreen from './src/screens/CreateBulkBoltcardScreen';
 import HelpScreen from './src/screens/HelpScreen';
 import ReadNFCScreen from './src/screens/ReadNFCScreen';
-import ResetKeysScreen from './src/screens/ResetKeysScreen';
+import WipeCardScreen from './src/screens/WipeCardScreen';
 import ScanScreen from './src/screens/ScanScreen';
 
 import {LogBox} from 'react-native';
@@ -134,125 +135,7 @@ export default function App(props) {
     <PaperProvider theme={theme}>
       <LaWalletProvider>
         <NavigationContainer>
-          <Tab.Navigator
-            screenOptions={({route}) => ({
-              tabBarIcon: ({focused, color, size}) => {
-                let iconName;
-
-                if (route.name === 'Link QR') {
-                  iconName = focused ? 'qr-code' : 'qr-code-outline';
-                } else if (route.name === 'Create Bulk Bolt Card') {
-                  iconName = focused
-                    ? 'file-tray-stacked'
-                    : 'file-tray-stacked-outline';
-                } else if (route.name === 'Help') {
-                  iconName = focused ? 'information' : 'information-outline';
-                } else if (route.name === 'Login') {
-                  iconName = focused ? 'person' : 'person-outline';
-                } else if (route.name === 'Advanced') {
-                  iconName = focused ? 'settings' : 'settings-outline';
-                } else if (route.name === 'Read NFC') {
-                  iconName = focused ? 'book' : 'book-outline';
-                } else if (route.name === 'Reset Keys') {
-                  iconName = focused ? 'key' : 'key-outline';
-                }
-
-                // You can return any component that you like here!
-                return <Ionicons name={iconName} size={size} color={color} />;
-              },
-              tabBarActiveTintColor: '#f58340',
-              tabBarInactiveTintColor: 'gray',
-            })}>
-            <Tab.Screen
-              name="Reset Keys"
-              children={() => (
-                <CreateBoltcardStack.Navigator
-                  screenOptions={{
-                    headerShown: false,
-                  }}>
-                  <CreateBoltcardStack.Screen
-                    name="ResetKeysScreen"
-                    component={ResetKeysScreen}
-                    initialParams={{data: null}}
-                  />
-                  <CreateBoltcardStack.Screen
-                    name="ScanScreenReset"
-                    component={ScanScreen}
-                  />
-                </CreateBoltcardStack.Navigator>
-              )}
-            />
-            <Tab.Screen name="Read NFC" component={ReadNFCScreen} />
-            <Tab.Screen
-              name="Create Bulk Bolt Card"
-              component={CreateBulkBoltcardScreen}
-            />
-
-            {/* <Tab.Screen
-            name="Link QR"
-            component={LinkCardQRScreen}
-            options={{
-              headerTitle: props => (
-                <LogoTitle title="Link Card to QR" {...props} />
-              ),
-            }}
-          /> */}
-
-            {/* <Tab.Screen
-              name="Link QR"
-              options={{
-                headerTitle: props => (
-                  <LogoTitle title="Link Card to QR" {...props} />
-                ),
-              }}
-              children={() => (
-                <CreateBoltcardStack.Navigator
-                  screenOptions={{
-                    headerShown: false,
-                  }}>
-                  <CreateBoltcardStack.Screen
-                    name="Link QR Main"
-                    component={LinkCardQRScreen}
-                    initialParams={{data: null}}
-                  />
-                  <CreateBoltcardStack.Screen
-                    name="ScanScreen"
-                    component={ScanScreen}
-                  />
-                </CreateBoltcardStack.Navigator>
-              )}
-            />
-            <Tab.Screen
-              name="Help"
-              component={HelpScreen}
-              options={{
-                headerTitle: props => <LogoTitle title="Help" {...props} />,
-              }}
-            /> */}
-
-            <Tab.Screen
-              name="Login"
-              options={{
-                headerTitle: props => <LogoTitle title="Login" {...props} />,
-              }}
-              children={() => (
-                <CreateBoltcardStack.Navigator
-                  screenOptions={{
-                    headerShown: false,
-                  }}>
-                  <CreateBoltcardStack.Screen
-                    name="LoginScreen"
-                    component={LoginScreen}
-                    initialParams={{data: null}}
-                  />
-                  <CreateBoltcardStack.Screen
-                    name="ScanScreenLogin"
-                    component={ScanScreen}
-                  />
-                </CreateBoltcardStack.Navigator>
-              )}
-            />
-          </Tab.Navigator>
+          <MainTabs />
         </NavigationContainer>
         <ErrorModal
           modalText={modalText}
@@ -262,6 +145,61 @@ export default function App(props) {
         <Toast />
       </LaWalletProvider>
     </PaperProvider>
+  );
+}
+
+function MainTabs() {
+  const {isLogged} = useLaWallet();
+
+  return (
+    <Tab.Navigator
+      screenOptions={({route}) => ({
+        tabBarIcon: ({focused, color, size}) => {
+          let iconName;
+          if (route.name === 'Bulk Create') {
+            iconName = focused ? 'file-tray-stacked' : 'file-tray-stacked-outline';
+          } else if (route.name === 'Login') {
+            iconName = focused ? 'person' : 'person-outline';
+          } else if (route.name === 'Read NFC') {
+            iconName = focused ? 'book' : 'book-outline';
+          } else if (route.name === 'Wipe Card') {
+            iconName = focused ? 'trash-bin' : 'trash-bin-outline';
+          }
+          return <Ionicons name={iconName} size={size} color={color} />;
+        },
+        tabBarActiveTintColor: '#f58340',
+        tabBarInactiveTintColor: 'gray',
+      })}>
+      {/* Always visible */}
+      <Tab.Screen name="Read NFC" component={ReadNFCScreen} />
+
+      {/* Only visible when logged in */}
+      {isLogged && (
+        <Tab.Screen name="Bulk Create" component={CreateBulkBoltcardScreen} />
+      )}
+      {isLogged && (
+        <Tab.Screen name="Wipe Card" component={WipeCardScreen} />
+      )}
+
+      {/* Always visible — Login stack with scan sub-screen */}
+      <Tab.Screen
+        name="Login"
+        options={{headerTitle: props => <LogoTitle title="Login" {...props} />}}
+        children={() => (
+          <CreateBoltcardStack.Navigator screenOptions={{headerShown: false}}>
+            <CreateBoltcardStack.Screen
+              name="LoginScreen"
+              component={LoginScreen}
+              initialParams={{data: null}}
+            />
+            <CreateBoltcardStack.Screen
+              name="ScanScreenLogin"
+              component={ScanScreen}
+            />
+          </CreateBoltcardStack.Navigator>
+        )}
+      />
+    </Tab.Navigator>
   );
 }
 

--- a/src/components/WriteModal.js
+++ b/src/components/WriteModal.js
@@ -1,5 +1,5 @@
 import React, {useCallback, useEffect, useState} from 'react';
-import {StyleSheet, View} from 'react-native';
+import {Image, StyleSheet, View} from 'react-native';
 import {ActivityIndicator, Text} from 'react-native-paper';
 import Dialog from 'react-native-dialog';
 
@@ -14,7 +14,7 @@ import Ntag424 from '../class/Ntag424';
  */
 
 export default function WriteModal(props) {
-  const {cardData} = props;
+  const {cardData, skin} = props;
 
   // Changed
   const [key0Changed, setKey0Changed] = useState(false);
@@ -28,6 +28,9 @@ export default function WriteModal(props) {
   // Test
   const [testBolt, setTestBolt] = useState();
   const [error, setError] = useState();
+
+  // Selected skin image natural aspect ratio (for full, uncropped display)
+  const [skinAspect, setSkinAspect] = useState(1.586);
 
   // Reset
   const reset = useCallback(() => {
@@ -178,8 +181,46 @@ export default function WriteModal(props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cardData]);
 
+  // Measure the skin image so the preview shows it in full (no cropping).
+  useEffect(() => {
+    if (!skin?.file) {
+      return;
+    }
+    let active = true;
+    const src = skin.file;
+    if (typeof src === 'string') {
+      Image.getSize(
+        src,
+        (w, h) => {
+          if (active && w && h) setSkinAspect(w / h);
+        },
+        () => {},
+      );
+    } else {
+      const resolved = Image.resolveAssetSource(src);
+      if (resolved?.width && resolved?.height) {
+        setSkinAspect(resolved.width / resolved.height);
+      }
+    }
+    return () => {
+      active = false;
+    };
+  }, [skin]);
+
   return (
     <Dialog.Container visible={props.visible}>
+      {/* Selected skin preview */}
+      {skin && (
+        <View style={styles.skinPreview}>
+          <Image
+            source={typeof skin.file === 'string' ? {uri: skin.file} : skin.file}
+            style={[styles.skinImage, {aspectRatio: skinAspect}]}
+            resizeMode="contain"
+          />
+          <Text style={styles.skinLabel}>{skin.label}</Text>
+        </View>
+      )}
+
       <Dialog.Title>
         <Ionicons name="card" size={30} color="green" />
         <Text style={styles.text}> Hold NFC card</Text>
@@ -213,6 +254,25 @@ export default function WriteModal(props) {
 }
 
 const styles = StyleSheet.create({
+  skinPreview: {
+    // Bleed past the dialog's 16px content padding so the card is near
+    // full-width, leaving only a tiny (~4px) margin on each side / top.
+    marginTop: -12,
+    marginHorizontal: -12,
+    marginBottom: 10,
+    alignItems: 'center',
+  },
+  skinImage: {
+    width: '100%',
+    borderRadius: 8,
+  },
+  skinLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#444',
+    textAlign: 'center',
+    marginTop: 8,
+  },
   text: {
     fontSize: 20,
     textAlign: 'center',

--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -10,6 +10,7 @@ export interface DeviceJwtClaims {
   aud: string;
   exp: number; // seconds since epoch
   iat: number;
+  apiUrl?: string; // LaWallet instance URL — auto-sets baseUrl on login
 }
 
 function base64urlDecode(str: string): string {

--- a/src/providers/LaWallet.tsx
+++ b/src/providers/LaWallet.tsx
@@ -128,6 +128,9 @@ export const LaWalletProvider = ({children}: {children: React.ReactNode}) => {
           const decoded = decodeJwt(storedToken);
           if (decoded && !isExpired(decoded)) {
             applyJwt(storedToken, decoded);
+            // Fetch server designs so the Bulk Create screen shows the
+            // correct skins instead of the hardcoded fallback list.
+            fetchDesigns().catch(() => {});
           } else {
             // Keep the base URL but drop the stale token.
             await SecureStorage.removeItem(STORAGE_KEYS.DEVICE_TOKEN);
@@ -180,15 +183,20 @@ export const LaWalletProvider = ({children}: {children: React.ReactNode}) => {
     try {
       const res = await authFetch('/api/card-designs/list');
       if (res.ok) {
-        const designs: CardDesign[] = await res.json();
+        const body = await res.json();
+        // Handle both plain array and {data:[]} wrapper shapes
+        const designs: CardDesign[] = Array.isArray(body) ? body : (body?.data ?? []);
+        console.log('[fetchDesigns] received', designs.length, 'designs');
         const mapped: Skin[] = designs
           .filter(d => !d.archivedAt)
           .map(d => ({label: d.description, value: d.id, file: d.imageUrl}));
         setSkins(mapped.length > 0 ? mapped : skinsFile);
       } else {
+        console.log('[fetchDesigns] non-ok response', res.status);
         setSkins(skinsFile);
       }
-    } catch {
+    } catch (e) {
+      console.log('[fetchDesigns] error', e);
       setSkins(skinsFile);
     }
   }, [authFetch]);
@@ -212,6 +220,14 @@ export const LaWalletProvider = ({children}: {children: React.ReactNode}) => {
       const decoded = decodeJwt(token);
       if (!decoded) return {ok: false, reason: 'invalid'};
       if (isExpired(decoded)) return {ok: false, reason: 'expired'};
+
+      // If the JWT carries an apiUrl, adopt it as the base URL so the
+      // operator never has to type it manually.
+      if (decoded.apiUrl) {
+        const normalized = normalizeBaseUrl(decoded.apiUrl);
+        applyBaseUrl(normalized);
+        SecureStorage.setItem(STORAGE_KEYS.BASE_URL, normalized).catch(() => {});
+      }
 
       // Update refs first so authFetch (used by fetchDesigns) sees the new token.
       applyJwt(token, decoded);

--- a/src/screens/CreateBulkBoltcardScreen.tsx
+++ b/src/screens/CreateBulkBoltcardScreen.tsx
@@ -1,18 +1,20 @@
 /* eslint-disable no-alert */
 /* eslint-disable react-native/no-inline-styles */
 import {useNavigation} from '@react-navigation/native';
-import React, {useCallback, useEffect, useState} from 'react';
-import {Dropdown} from 'react-native-element-dropdown';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {
   ActivityIndicator,
-  Button,
+  Animated,
   ScrollView,
   StyleSheet,
   Text,
+  TextInput,
   ToastAndroid,
+  TouchableOpacity,
   Image,
+  View,
 } from 'react-native';
-import {Card, Title} from 'react-native-paper';
+import Ionicons from 'react-native-vector-icons/Ionicons';
 
 import NfcManager, {NfcTech} from 'react-native-nfc-manager';
 import WriteModal from '../components/WriteModal';
@@ -21,6 +23,8 @@ import {useLaWallet, AuthError} from '../providers/LaWallet';
 import {Ntag424WriteData} from '../types/response';
 import {Skin} from '../types/skin';
 
+// ─── Constants ───────────────────────────────────────────────────────────────
+
 const CardStatus = {
   IDLE: 'idle',
   READING: 'reading',
@@ -28,17 +32,136 @@ const CardStatus = {
   WRITING: 'writing',
 };
 
+// ─── Skin Card Item ───────────────────────────────────────────────────────────
+
+function SkinItem({
+  item,
+  selected,
+  onPress,
+}: {
+  item: Skin;
+  selected: boolean;
+  onPress: () => void;
+}) {
+  const [loading, setLoading] = useState(true);
+  const [aspectRatio, setAspectRatio] = useState(1.586); // default card ratio
+  const fade = useRef(new Animated.Value(0)).current;
+
+  // Measure the image's natural size so it can be shown in full (no cropping).
+  useEffect(() => {
+    let active = true;
+    const src = item.file;
+    if (typeof src === 'string') {
+      Image.getSize(
+        src,
+        (w, h) => {
+          if (active && w && h) setAspectRatio(w / h);
+        },
+        () => {},
+      );
+    } else {
+      const resolved = Image.resolveAssetSource(src);
+      if (resolved?.width && resolved?.height) {
+        setAspectRatio(resolved.width / resolved.height);
+      }
+    }
+    return () => {
+      active = false;
+    };
+  }, [item.file]);
+
+  return (
+    <TouchableOpacity
+      style={[styles.skinCard, selected && styles.skinCardSelected]}
+      onPress={onPress}
+      activeOpacity={0.8}>
+      {/* Image */}
+      <View style={[styles.skinImageWrap, {aspectRatio}]}>
+        {loading && (
+          <View style={styles.skinImageSkeleton}>
+            <ActivityIndicator size="large" color="#ccc" />
+          </View>
+        )}
+        <Animated.Image
+          source={typeof item.file === 'string' ? {uri: item.file} : item.file}
+          style={[styles.skinImage, {opacity: fade}]}
+          resizeMode="contain"
+          onLoadStart={() => {
+            setLoading(true);
+            fade.setValue(0);
+          }}
+          onLoad={() => {
+            setLoading(false);
+            Animated.timing(fade, {
+              toValue: 1,
+              duration: 300,
+              useNativeDriver: true,
+            }).start();
+          }}
+        />
+        {/* Selected checkmark overlay */}
+        {selected && (
+          <View style={styles.skinCheckOverlay}>
+            <Ionicons name="checkmark" size={18} color="#fff" />
+          </View>
+        )}
+      </View>
+      {/* Name */}
+      <View style={styles.skinFooter}>
+        <Text style={[styles.skinName, selected && styles.skinNameSelected]}>
+          {item.label}
+        </Text>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+// ─── Screen ──────────────────────────────────────────────────────────────────
+
 export default function CreateBulkBoltcardScreen() {
   const [cardData, setCardData] = useState<Ntag424WriteData | undefined>();
-
   const [cardStatus, setCardStatus] = useState(CardStatus.IDLE);
-
-  const [openSkin, setOpenSkin] = useState(false);
   const [skin, setSkin] = useState<Skin | undefined>();
+  const [search, setSearch] = useState('');
   const [error, setError] = useState<string>();
+  const [skinAspect, setSkinAspect] = useState(1.586);
+
+  const [refreshing, setRefreshing] = useState(false);
+  const refreshSpin = useRef(new Animated.Value(0)).current;
 
   const navigation = useNavigation();
-  const {isLogged, skins, authFetch, baseUrl} = useLaWallet();
+  const {isLogged, skins, authFetch, baseUrl, fetchDesigns} = useLaWallet();
+
+  const cancelledByUser = useRef(false);
+  // Timestamp of the last scroll event — used to ignore taps mid-scroll.
+  const lastScrollTs = useRef(0);
+
+  const handleRefresh = useCallback(async () => {
+    if (refreshing) return;
+    setRefreshing(true);
+    // Spin animation while fetching
+    Animated.loop(
+      Animated.timing(refreshSpin, {
+        toValue: 1,
+        duration: 700,
+        useNativeDriver: true,
+      }),
+    ).start();
+    try {
+      await fetchDesigns();
+    } finally {
+      setRefreshing(false);
+      refreshSpin.stopAnimation();
+      refreshSpin.setValue(0);
+    }
+  }, [refreshing, fetchDesigns, refreshSpin]);
+
+  // Filtered skins list
+  const filteredSkins = skins.filter(s =>
+    s.label.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  // ── Card creation ──────────────────────────────────────────────────────────
 
   const requestCreateCard = useCallback(
     async (_cardUID: string, _skin: Skin) => {
@@ -52,7 +175,6 @@ export default function CreateBulkBoltcardScreen() {
       );
 
       try {
-        // 1. Create the card on the backend (auth-gated: cards:write scope).
         const createRes = await authFetch('/api/cards', {
           method: 'POST',
           body: JSON.stringify({
@@ -72,8 +194,6 @@ export default function CreateBulkBoltcardScreen() {
         const createdCard = await createRes.json();
         const cardId: string = createdCard.id;
 
-        // 2. Fetch the canonical write payload (public endpoint — no auth needed).
-        //    It includes the lnurlw_base and keys already assembled by the server.
         let writeData: Ntag424WriteData;
         try {
           const writeRes = await fetch(`${baseUrl}/api/cards/${cardId}/write`);
@@ -83,24 +203,16 @@ export default function CreateBulkBoltcardScreen() {
             throw new Error(`write endpoint returned ${writeRes.status}`);
           }
         } catch (writeErr) {
-          // Fallback: build the payload from the POST response keys.
           console.warn('CreateBulk: write endpoint failed, using POST keys', writeErr);
           const ntag = createdCard.ntag424;
           const host = (() => {
-            try {
-              return new URL(baseUrl).host;
-            } catch {
-              return baseUrl.replace(/^https?:\/\//, '').split('/')[0];
-            }
+            try { return new URL(baseUrl).host; }
+            catch { return baseUrl.replace(/^https?:\/\//, '').split('/')[0]; }
           })();
           writeData = {
             card_name: createdCard.title || 'New Card',
             id: ntag.cid,
-            k0: ntag.k0,
-            k1: ntag.k1,
-            k2: ntag.k2,
-            k3: ntag.k3,
-            k4: ntag.k4,
+            k0: ntag.k0, k1: ntag.k1, k2: ntag.k2, k3: ntag.k3, k4: ntag.k4,
             lnurlw_base: `lnurlw://${host}/api/cards/${cardId}/scan`,
             protocol_name: 'new_bolt_card_response',
             protocol_version: '1',
@@ -117,8 +229,7 @@ export default function CreateBulkBoltcardScreen() {
             ToastAndroid.TOP,
           );
         } else {
-          const msg =
-            err instanceof Error ? err.message : JSON.stringify(err);
+          const msg = err instanceof Error ? err.message : JSON.stringify(err);
           setError(msg);
           alert(msg);
         }
@@ -131,14 +242,6 @@ export default function CreateBulkBoltcardScreen() {
   const onReadCard = useCallback(
     (event: any) => {
       const _cardUID = event.id?.toLowerCase();
-      console.log(
-        event.key0Changed,
-        event.key1Changed,
-        event.key2Changed,
-        event.key3Changed,
-        event.key4Changed,
-      );
-
       if (event.key0Changed) {
         ToastAndroid.showWithGravity(
           'The card is already setup',
@@ -147,7 +250,6 @@ export default function CreateBulkBoltcardScreen() {
         );
         return;
       }
-
       try {
         requestCreateCard(_cardUID, skin!);
       } catch (e: any) {
@@ -159,31 +261,62 @@ export default function CreateBulkBoltcardScreen() {
   );
 
   const startReading = useCallback(async () => {
+    cancelledByUser.current = false;
     await NfcManager.start();
     await NfcManager.cancelTechnologyRequest();
     await NfcManager.clearBackgroundTag();
     try {
-      console.info('START reading...');
       await NfcManager.requestTechnology(NfcTech.IsoDep);
       const tag = await NfcManager.getTag();
       onReadCard(tag);
     } catch (e: any) {
       setCardStatus(CardStatus.IDLE);
-      alert(e?.message);
-      console.error(e?.message);
+      // Only surface genuine errors — suppress user-initiated cancels and
+      // message-less rejections (which would render a blank "Alert").
+      if (!cancelledByUser.current && e?.message) {
+        alert(e.message);
+      }
+      cancelledByUser.current = false;
     }
   }, [onReadCard]);
 
-  // On exit screen
+  // Cancel NFC on tab blur
   useEffect(() => {
     const unsubscribe = navigation.addListener('blur', () => {
+      cancelledByUser.current = true;
       setCardStatus(CardStatus.IDLE);
       NfcManager.cancelTechnologyRequest();
     });
     return unsubscribe;
   }, [navigation]);
 
-  // React to cardStatus changes
+  // Measure the selected skin image so the bottom preview shows it in full.
+  useEffect(() => {
+    if (!skin?.file) {
+      return;
+    }
+    let active = true;
+    const src = skin.file;
+    if (typeof src === 'string') {
+      Image.getSize(
+        src,
+        (w, h) => {
+          if (active && w && h) setSkinAspect(w / h);
+        },
+        () => {},
+      );
+    } else {
+      const resolved = Image.resolveAssetSource(src);
+      if (resolved?.width && resolved?.height) {
+        setSkinAspect(resolved.width / resolved.height);
+      }
+    }
+    return () => {
+      active = false;
+    };
+  }, [skin]);
+
+  // Drive NFC on status change
   useEffect(() => {
     switch (cardStatus) {
       case CardStatus.READING:
@@ -197,121 +330,166 @@ export default function CreateBulkBoltcardScreen() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cardStatus]);
 
-  if (!isLogged) {
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  // NFC / creating in progress
+  if (cardStatus === CardStatus.READING || cardStatus === CardStatus.CREATING_CARD) {
+    // Fit the selected card image within a bounded preview box (no cropping).
+    let previewW = 200;
+    let previewH = previewW / skinAspect;
+    if (previewH > 240) {
+      previewH = 240;
+      previewW = previewH * skinAspect;
+    }
     return (
-      <Card
-        style={{
-          marginBottom: 20,
-          marginTop: 10,
-          marginHorizontal: 10,
-          zIndex: 1000,
-        }}>
-        <Card.Content>
-          <Text>Not logged in — go to the Login tab to authenticate.</Text>
-        </Card.Content>
-      </Card>
+      <View style={styles.nfcCenter}>
+        <View style={styles.nfcMain}>
+          <Animated.View>
+            <Ionicons name="wifi-outline" size={80} color="#f58340" style={styles.nfcIcon} />
+          </Animated.View>
+          <Text style={styles.nfcTitle}>
+            {cardStatus === CardStatus.CREATING_CARD ? 'Creating card…' : 'Hold card to phone'}
+          </Text>
+          {cardStatus === CardStatus.CREATING_CARD && (
+            <ActivityIndicator size="small" color="#f58340" style={{marginTop: 8}} />
+          )}
+          <TouchableOpacity
+            style={styles.cancelBtn}
+            onPress={() => {
+              cancelledByUser.current = true;
+              NfcManager.cancelTechnologyRequest();
+              setCardStatus(CardStatus.IDLE);
+            }}>
+            <Text style={styles.cancelBtnText}>Cancel</Text>
+          </TouchableOpacity>
+        </View>
+
+        {/* Card being written — bottom preview */}
+        {skin && (
+          <View style={styles.nfcCardPreview}>
+            <Text style={styles.nfcCardCaption}>CARD TO WRITE</Text>
+            <View style={styles.nfcCardImageWrap}>
+              <Image
+                source={
+                  typeof skin.file === 'string' ? {uri: skin.file} : skin.file
+                }
+                style={{width: previewW, height: previewH}}
+                resizeMode="contain"
+              />
+            </View>
+            <Text style={styles.nfcCardLabel}>{skin.label}</Text>
+          </View>
+        )}
+      </View>
     );
   }
 
+  // Skin gallery (IDLE state)
   return (
-    <ScrollView style={{}}>
-      {cardStatus === CardStatus.READING ? (
-        <Text
-          style={{
-            margin: 20,
-            fontWeight: 'bold',
-            fontSize: 15,
-            textAlign: 'center',
-          }}>
-          <ActivityIndicator />
-          <Text>Hold NFC card to Reader</Text>
-        </Text>
-      ) : (
-        <>
-          {skin && cardStatus === CardStatus.IDLE && (
-            <Card style={{marginHorizontal: 10}}>
-              <Button
-                onPress={() => setCardStatus(CardStatus.READING)}
-                title="Start reading"
-              />
-            </Card>
-          )}
-        </>
-      )}
-
-      <Card
-        style={{
-          marginBottom: 20,
-          marginTop: 10,
-          marginHorizontal: 10,
-          zIndex: 1000,
-        }}>
-        <Card.Content>
-          {cardStatus === CardStatus.IDLE && (
-            <>
-              <Title>Card skin</Title>
-              <Dropdown
-                style={[styles.dropdown, openSkin && {borderColor: 'blue'}]}
-                data={skins}
-                search
-                maxHeight={300}
-                labelField="label"
-                valueField="value"
-                placeholder={!openSkin ? 'Select item' : '...'}
-                searchPlaceholder="Search..."
-                value={skin ? skin.value : null}
-                onFocus={() => setOpenSkin(true)}
-                onBlur={() => setOpenSkin(false)}
-                onChange={item => {
-                  console.info('******** ITEM ********');
-                  console.info(JSON.stringify(item));
-                  setSkin(item);
-                  setOpenSkin(false);
-                }}
-              />
-            </>
-          )}
-
+    <View style={styles.container}>
+      {/* Header */}
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>Select Skin</Text>
+        <View style={styles.headerActions}>
           {skin && (
-            <Image
-              style={styles.cardImage}
-              source={
-                typeof skin.file === 'string' ? {uri: skin.file} : skin.file
-              }
-            />
+            <TouchableOpacity onPress={() => setSkin(undefined)} style={styles.clearBtn}>
+              <Text style={styles.clearBtnText}>Clear</Text>
+            </TouchableOpacity>
           )}
-        </Card.Content>
-      </Card>
+          <TouchableOpacity
+            onPress={handleRefresh}
+            style={styles.refreshBtn}
+            disabled={refreshing}>
+            <Animated.View style={{
+              transform: [{
+                rotate: refreshSpin.interpolate({
+                  inputRange: [0, 1],
+                  outputRange: ['0deg', '360deg'],
+                }),
+              }],
+            }}>
+              <Ionicons name="refresh" size={20} color={refreshing ? '#ccc' : '#555'} />
+            </Animated.View>
+          </TouchableOpacity>
+        </View>
+      </View>
 
-      {(cardStatus === CardStatus.READING || skin) && (
-        <Card style={styles.card}>
-          <Card.Content>
-            <Button
-              onPress={() => {
-                setCardStatus(CardStatus.IDLE);
-                setSkin(undefined);
-              }}
-              title="Cancelar"
-            />
-          </Card.Content>
-        </Card>
+      {/* Hint */}
+      <Text style={styles.headerHint}>Tap a card to select it</Text>
+
+      {/* Search */}
+      <View style={styles.searchWrap}>
+        <Ionicons name="search-outline" size={16} color="#aaa" style={styles.searchIcon} />
+        <TextInput
+          style={styles.searchInput}
+          placeholder="Search skins…"
+          placeholderTextColor="#aaa"
+          value={search}
+          onChangeText={setSearch}
+          autoCapitalize="none"
+          autoCorrect={false}
+        />
+        {search.length > 0 && (
+          <TouchableOpacity onPress={() => setSearch('')}>
+            <Ionicons name="close-circle" size={16} color="#aaa" />
+          </TouchableOpacity>
+        )}
+      </View>
+
+      {/* Error banner */}
+      {error && (
+        <View style={styles.errorBanner}>
+          <Ionicons name="alert-circle-outline" size={14} color="#fff" />
+          <Text style={styles.errorText}>{error}</Text>
+        </View>
       )}
 
-      {error && (
-        <Card
-          style={{
-            marginBottom: 20,
-            marginTop: 10,
-            marginHorizontal: 10,
-            zIndex: 1000,
-          }}>
-          <Card.Content>
-            <>
-              <Title>error</Title>
-              <Text>{error}</Text>
-            </>
-          </Card.Content>
-        </Card>
+      {/* Skin list */}
+      <ScrollView
+        style={styles.list}
+        contentContainerStyle={[
+          styles.listContent,
+          // Extra bottom padding when action bar is visible
+          skin ? {paddingBottom: 90} : {paddingBottom: 20},
+        ]}
+        scrollEventThrottle={16}
+        onScroll={() => {
+          lastScrollTs.current = Date.now();
+        }}
+        keyboardShouldPersistTaps="handled">
+        {filteredSkins.length === 0 ? (
+          <View style={styles.emptyWrap}>
+            <Ionicons name="images-outline" size={40} color="#ccc" />
+            <Text style={styles.emptyText}>No skins found</Text>
+          </View>
+        ) : (
+          filteredSkins.map(item => (
+            <SkinItem
+              key={item.value}
+              item={item}
+              selected={skin?.value === item.value}
+              onPress={() => {
+                // Ignore taps that land during or right after a scroll gesture.
+                if (Date.now() - lastScrollTs.current > 150) {
+                  setSkin(item);
+                }
+              }}
+            />
+          ))
+        )}
+      </ScrollView>
+
+      {/* Sticky action bar */}
+      {skin && (
+        <View style={styles.actionBar}>
+          <TouchableOpacity
+            style={styles.tapCardBtn}
+            onPress={() => setCardStatus(CardStatus.READING)}
+            activeOpacity={0.85}>
+            <Ionicons name="wifi-outline" size={20} color="#fff" style={styles.nfcIcon} />
+            <Text style={styles.tapCardBtnText}>Tap Card to Write</Text>
+          </TouchableOpacity>
+        </View>
       )}
 
       <WriteModal
@@ -319,35 +497,210 @@ export default function CreateBulkBoltcardScreen() {
         onCancel={() => setCardStatus(CardStatus.IDLE)}
         onSuccess={() => setCardStatus(CardStatus.READING)}
         cardData={cardData}
+        skin={skin}
       />
-    </ScrollView>
+    </View>
   );
 }
 
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
 const styles = StyleSheet.create({
-  card: {
-    marginBottom: 20,
-    marginHorizontal: 10,
+  container: {flex: 1, backgroundColor: '#f2f2f2'},
+
+  // Header
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    paddingBottom: 8,
   },
-  spaceAround: {
-    justifyContent: 'space-around',
+  headerTitle: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    color: '#111',
   },
-  dropdown: {
-    height: 50,
-    borderColor: 'gray',
-    borderWidth: 0.5,
-    borderRadius: 8,
-    paddingHorizontal: 8,
+  headerHint: {
+    fontSize: 12,
+    color: '#999',
+    paddingHorizontal: 16,
     marginBottom: 10,
   },
-  text: {
-    fontSize: 20,
-    textAlign: 'center',
-    borderColor: 'black',
+  headerActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
   },
-  cardImage: {
+  clearBtn: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+    backgroundColor: '#eee',
+  },
+  clearBtnText: {fontSize: 13, color: '#555'},
+  refreshBtn: {
+    padding: 8,
+    borderRadius: 8,
+  },
+
+  // Search
+  searchWrap: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#fff',
+    borderRadius: 10,
+    marginHorizontal: 16,
+    marginBottom: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    gap: 8,
+    elevation: 1,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowRadius: 4,
+    shadowOffset: {width: 0, height: 2},
+  },
+  searchIcon: {},
+  searchInput: {
+    flex: 1,
+    fontSize: 14,
+    color: '#222',
+    paddingVertical: 0,
+  },
+
+  // Error
+  errorBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    backgroundColor: '#c0392b',
+    marginHorizontal: 16,
+    borderRadius: 8,
+    padding: 10,
+    marginBottom: 8,
+  },
+  errorText: {fontSize: 13, color: '#fff', flex: 1},
+
+  // List
+  list: {flex: 1},
+  listContent: {paddingHorizontal: 16, gap: 12},
+  emptyWrap: {alignItems: 'center', paddingTop: 60, gap: 12},
+  emptyText: {fontSize: 14, color: '#bbb'},
+
+  // Skin card
+  skinCard: {
+    borderRadius: 14,
+    overflow: 'hidden',
+    backgroundColor: '#fff',
+    borderWidth: 2.5,
+    borderColor: 'transparent',
+    elevation: 2,
+    shadowColor: '#000',
+    shadowOpacity: 0.08,
+    shadowRadius: 6,
+    shadowOffset: {width: 0, height: 3},
+  },
+  skinCardSelected: {
+    borderColor: '#f58340',
+  },
+  skinImageWrap: {
     width: '100%',
-    height: 200,
-    borderRadius: 15,
+    backgroundColor: '#e8e8e8',
   },
+  skinImageSkeleton: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#e8e8e8',
+  },
+  skinImage: {width: '100%', height: '100%'},
+  skinCheckOverlay: {
+    position: 'absolute',
+    top: 10,
+    right: 10,
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: 'rgba(245,131,64,0.85)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  skinFooter: {
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+  },
+  skinName: {fontSize: 14, fontWeight: '600', color: '#333'},
+  skinNameSelected: {color: '#f58340'},
+
+  // Sticky action bar
+  actionBar: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    padding: 16,
+    backgroundColor: '#f2f2f2',
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: '#ddd',
+  },
+  tapCardBtn: {
+    backgroundColor: '#f58340',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    paddingVertical: 16,
+    borderRadius: 12,
+  },
+  tapCardBtnText: {color: '#fff', fontWeight: 'bold', fontSize: 17},
+
+  // NFC waiting screen
+  nfcCenter: {
+    flex: 1,
+    alignItems: 'center',
+    paddingHorizontal: 40,
+    paddingTop: 40,
+    paddingBottom: 28,
+    backgroundColor: '#f2f2f2',
+  },
+  nfcMain: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 16,
+  },
+  nfcCardPreview: {
+    alignItems: 'center',
+    gap: 10,
+  },
+  nfcCardCaption: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#999',
+    letterSpacing: 1,
+  },
+  nfcCardImageWrap: {
+    borderRadius: 12,
+    overflow: 'hidden',
+    backgroundColor: '#fff',
+    elevation: 3,
+    shadowColor: '#000',
+    shadowOpacity: 0.12,
+    shadowRadius: 8,
+    shadowOffset: {width: 0, height: 3},
+  },
+  nfcCardLabel: {fontSize: 15, fontWeight: '600', color: '#333'},
+  nfcIcon: {transform: [{rotate: '90deg'}]},
+  nfcTitle: {fontSize: 20, fontWeight: 'bold', color: '#333', textAlign: 'center'},
+  cancelBtn: {
+    marginTop: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 28,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#ccc',
+  },
+  cancelBtnText: {fontSize: 14, color: '#666'},
 });

--- a/src/screens/Login.tsx
+++ b/src/screens/Login.tsx
@@ -2,11 +2,13 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {useNavigation} from '@react-navigation/native';
 import {
+  ActivityIndicator,
   Alert,
+  Animated,
+  Image,
   ScrollView,
   StyleSheet,
   Text,
-  TextInput,
   TouchableOpacity,
   View,
 } from 'react-native';
@@ -14,6 +16,9 @@ import {Card, ProgressBar, Title} from 'react-native-paper';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import {useLaWallet} from '../providers/LaWallet';
 import {secondsUntilExpiry} from '../lib/jwt';
+import type {InstanceSettings} from '../types/response';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function formatCountdown(secs: number): string {
   if (secs <= 0) return 'expired';
@@ -25,10 +30,129 @@ function formatCountdown(secs: number): string {
   return `${s}s`;
 }
 
+// ─── Instance Hero Card ───────────────────────────────────────────────────────
+
+const AVATAR_SIZE = 112;
+const AVATAR_HALF = AVATAR_SIZE / 2;
+
+/** Pulsing skeleton shown while settings are loading. */
+function HeroSkeleton() {
+  const pulse = useRef(new Animated.Value(0.4)).current;
+
+  useEffect(() => {
+    const anim = Animated.loop(
+      Animated.sequence([
+        Animated.timing(pulse, {toValue: 0.9, duration: 750, useNativeDriver: true}),
+        Animated.timing(pulse, {toValue: 0.4, duration: 750, useNativeDriver: true}),
+      ]),
+    );
+    anim.start();
+    return () => anim.stop();
+  }, [pulse]);
+
+  return (
+    <View style={styles.heroWrapper}>
+      <View style={styles.heroCover}>
+        <View style={styles.heroBg} />
+        <View style={styles.heroContent}>
+          <Animated.View style={[styles.skelTitle, {opacity: pulse}]} />
+          <View style={styles.heroPills}>
+            <Animated.View style={[styles.skelPill, {opacity: pulse}]} />
+            <Animated.View style={[styles.skelPill, {opacity: pulse, width: 140}]} />
+          </View>
+        </View>
+      </View>
+      {/* Avatar circle skeleton */}
+      <View style={styles.heroAvatarRow}>
+        <Animated.View style={[styles.heroAvatarCircle, styles.skelAvatar, {opacity: pulse}]}>
+          <ActivityIndicator size="small" color="#bbb" />
+        </Animated.View>
+      </View>
+    </View>
+  );
+}
+
+/** Loaded hero card with entrance animation. */
+function InstanceHero({settings}: {settings: InstanceSettings}) {
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+  const slideAnim = useRef(new Animated.Value(12)).current;
+  const [avatarLoading, setAvatarLoading] = useState(true);
+  const avatarFade = useRef(new Animated.Value(0)).current;
+
+  // Entrance animation on mount
+  useEffect(() => {
+    Animated.parallel([
+      Animated.timing(fadeAnim, {toValue: 1, duration: 400, useNativeDriver: true}),
+      Animated.timing(slideAnim, {toValue: 0, duration: 400, useNativeDriver: true}),
+    ]).start();
+  }, [fadeAnim, slideAnim]);
+
+  return (
+    <Animated.View style={[
+      styles.heroWrapper,
+      {opacity: fadeAnim, transform: [{translateY: slideAnim}]},
+    ]}>
+      {/* Black cover */}
+      <View style={styles.heroCover}>
+        <View style={styles.heroBg} />
+        <View style={styles.heroContent}>
+          <Text style={styles.heroName}>{settings.community_name}</Text>
+          <View style={styles.heroPills}>
+            <View style={styles.heroPill}>
+              <Ionicons name="globe-outline" size={11} color="rgba(255,255,255,0.75)" />
+              <Text style={styles.heroPillText}>{settings.domain}</Text>
+            </View>
+            <View style={styles.heroPill}>
+              <Ionicons name="server-outline" size={11} color="rgba(255,255,255,0.75)" />
+              <Text style={styles.heroPillText} numberOfLines={1}>
+                {settings.endpoint.replace(/^https?:\/\//, '')}
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+
+      {/* Avatar — centred, half above the cover */}
+      <View style={styles.heroAvatarRow}>
+        <View style={styles.heroAvatarCircle}>
+          {/* Spinner while image loads */}
+          {avatarLoading && (
+            <View style={styles.heroAvatarSpinner}>
+              <ActivityIndicator size="small" color="#bbb" />
+            </View>
+          )}
+          {settings.isotypo_url ? (
+            <Animated.Image
+              source={{uri: settings.isotypo_url}}
+              style={[styles.heroAvatarImg, {opacity: avatarFade}]}
+              resizeMode="contain"
+              onLoadStart={() => {
+                setAvatarLoading(true);
+                avatarFade.setValue(0);
+              }}
+              onLoad={() => {
+                setAvatarLoading(false);
+                Animated.timing(avatarFade, {
+                  toValue: 1,
+                  duration: 350,
+                  useNativeDriver: true,
+                }).start();
+              }}
+            />
+          ) : (
+            <Ionicons name="globe" size={48} color="#888" />
+          )}
+        </View>
+      </View>
+    </Animated.View>
+  );
+}
+
+// ─── Screen ──────────────────────────────────────────────────────────────────
+
 export default function LoginScreen({route}) {
   const {
     baseUrl,
-    setBaseUrl,
     loginWithToken,
     logout,
     isLogged,
@@ -40,17 +164,26 @@ export default function LoginScreen({route}) {
   } = useLaWallet();
 
   const navigation = useNavigation();
-
-  // Local state for the base URL text input (not persisted until Save).
-  const [urlInput, setUrlInput] = useState(baseUrl);
   const [isLoggingIn, setIsLoggingIn] = useState(false);
   const [countdown, setCountdown] = useState(0);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [instanceSettings, setInstanceSettings] =
+    useState<InstanceSettings | null>(null);
 
-  // Sync text input when baseUrl changes (e.g. on hydration).
+  // Fetch instance settings when logged in
+  const [settingsLoading, setSettingsLoading] = useState(false);
   useEffect(() => {
-    setUrlInput(baseUrl);
-  }, [baseUrl]);
+    if (!isLogged || !baseUrl) {
+      setInstanceSettings(null);
+      return;
+    }
+    setSettingsLoading(true);
+    fetch(`${baseUrl}/api/settings`)
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => setInstanceSettings(data))
+      .catch(() => {})
+      .finally(() => setSettingsLoading(false));
+  }, [isLogged, baseUrl]);
 
   // Expiry countdown ticker.
   useEffect(() => {
@@ -98,10 +231,6 @@ export default function LoginScreen({route}) {
     });
   }, [navigation]);
 
-  const handleSaveUrl = useCallback(async () => {
-    await setBaseUrl(urlInput);
-  }, [setBaseUrl, urlInput]);
-
   const handleLogout = useCallback(() => logout(), [logout]);
 
   const shortPubkey = pubkey
@@ -110,130 +239,326 @@ export default function LoginScreen({route}) {
 
   return (
     <View style={{flex: 1}}>
-    <ScrollView>
-      {/* Base URL configuration */}
-      <Card style={styles.card}>
-        <Card.Content>
-          <Title>LaWallet backend</Title>
-          <Text style={styles.label}>Base URL</Text>
-          <View style={styles.row}>
-            <TextInput
-              style={styles.urlInput}
-              value={urlInput}
-              onChangeText={setUrlInput}
-              placeholder="https://beta.lawallet.io"
-              autoCapitalize="none"
-              autoCorrect={false}
-              keyboardType="url"
-            />
-            <TouchableOpacity style={styles.saveBtn} onPress={handleSaveUrl}>
-              <Text style={styles.saveBtnText}>Save</Text>
-            </TouchableOpacity>
-          </View>
-        </Card.Content>
-      </Card>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
 
-      {/* Auth status */}
-      <Card style={styles.card}>
-        <Card.Content>
-          <Title>Session</Title>
+        {/* ── Logged-in view ── */}
+        {isLogged ? (
+          <>
+            {/* Instance hero — skeleton while loading, card when ready */}
+            {settingsLoading && !instanceSettings && <HeroSkeleton />}
+            {instanceSettings && <InstanceHero settings={instanceSettings} />}
 
-          {/* Expired banner */}
-          {tokenError === 'expired' && !isLogged && (
-            <View style={styles.banner}>
-              <Ionicons name="warning" size={16} color="#fff" />
-              <Text style={styles.bannerText}>
-                {' '}Session expired — scan a new token
-              </Text>
-            </View>
-          )}
-
-          {isLoading ? (
-            <Text>Loading…</Text>
-          ) : isLogged ? (
-            <>
-              <View style={styles.infoRow}>
-                <Ionicons name="checkmark-circle" size={18} color="green" />
-                <Text style={styles.infoText}> Logged in</Text>
-              </View>
-              <Text style={styles.detail}>Pubkey: {shortPubkey}</Text>
-              <Text style={styles.detail}>Scopes: {scopes.join(', ') || '—'}</Text>
-              <Text style={styles.detail}>
-                Expires in: {formatCountdown(countdown)}
-              </Text>
-              <TouchableOpacity style={styles.button} onPress={handleLogout}>
-                <Text style={styles.buttonText}>
-                  <Ionicons name="log-out" size={18} color="white" /> Logout
+            {/* Session card */}
+            <Card style={styles.card}>
+              <Card.Content>
+                <Title>Session</Title>
+                <View style={styles.infoRow}>
+                  <Ionicons name="checkmark-circle" size={18} color="green" />
+                  <Text style={styles.infoText}> Logged in</Text>
+                </View>
+                <Text style={styles.detail}>Pubkey: {shortPubkey}</Text>
+                <Text style={styles.detail}>
+                  Scopes: {scopes.join(', ') || '—'}
                 </Text>
-              </TouchableOpacity>
-            </>
-          ) : (
-            <>
-              <Text style={styles.detail}>Not logged in</Text>
-              <TouchableOpacity
-                style={[styles.button, !baseUrl && styles.buttonDisabled]}
-                onPress={handleScan}
-                disabled={!baseUrl}>
-                <Text style={styles.buttonText}>
-                  <Ionicons name="qr-code" size={18} color="white" /> Scan device token
+                <Text style={styles.detail}>
+                  Expires in: {formatCountdown(countdown)}
                 </Text>
-              </TouchableOpacity>
-              {!baseUrl && (
-                <Text style={styles.hint}>Set the base URL above first.</Text>
-              )}
-            </>
-          )}
-        </Card.Content>
-      </Card>
-    </ScrollView>
+                <TouchableOpacity style={styles.logoutBtn} onPress={handleLogout}>
+                  <Ionicons name="log-out" size={16} color="#c0392b" />
+                  <Text style={styles.logoutBtnText}>Logout</Text>
+                </TouchableOpacity>
+              </Card.Content>
+            </Card>
+          </>
+        ) : (
+          <>
+            {/* ── Logged-out view ── */}
+            {isLoading ? null : (
+              <Card style={styles.card}>
+                <Card.Content>
+                  <Title>Session</Title>
+
+                  {tokenError === 'expired' && (
+                    <View style={styles.banner}>
+                      <Ionicons name="warning" size={16} color="#fff" />
+                      <Text style={styles.bannerText}>
+                        {' '}Session expired — scan a new token
+                      </Text>
+                    </View>
+                  )}
+
+                  <View style={styles.instructionsBox}>
+                    <Text style={styles.instructionsTitle}>
+                      How to get your device token
+                    </Text>
+                    <View style={styles.instructionStep}>
+                      <Text style={styles.instructionNum}>1</Text>
+                      <Text style={styles.instructionText}>
+                        Log in to your LaWallet instance as admin{'\n'}
+                        <Text style={styles.instructionUrl}>
+                          e.g. beta.lawallet.io
+                        </Text>
+                      </Text>
+                    </View>
+                    <View style={styles.instructionStep}>
+                      <Text style={styles.instructionNum}>2</Text>
+                      <Text style={styles.instructionText}>
+                        Go to{' '}
+                        <Text style={styles.instructionBold}>
+                          Settings → Device Token
+                        </Text>
+                      </Text>
+                    </View>
+                    <View style={styles.instructionStep}>
+                      <Text style={styles.instructionNum}>3</Text>
+                      <Text style={styles.instructionText}>
+                        Tap{' '}
+                        <Text style={styles.instructionBold}>
+                          Generate token
+                        </Text>{' '}
+                        and scan the QR with this app
+                      </Text>
+                    </View>
+                  </View>
+
+                  <TouchableOpacity style={styles.scanBtn} onPress={handleScan}>
+                    <Ionicons name="qr-code" size={22} color="white" />
+                    <Text style={styles.scanBtnText}>Scan device token</Text>
+                  </TouchableOpacity>
+                </Card.Content>
+              </Card>
+            )}
+          </>
+        )}
+      </ScrollView>
 
       {isLoggingIn && (
         <View style={styles.loginOverlay}>
           <Text style={styles.loginOverlayTitle}>Logging in…</Text>
-          <ProgressBar indeterminate color="#1976D2" style={styles.loginProgressBar} />
+          <ProgressBar
+            indeterminate
+            color="#1976D2"
+            style={styles.loginProgressBar}
+          />
         </View>
       )}
     </View>
   );
 }
 
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
 const styles = StyleSheet.create({
+  scrollContent: {
+    paddingBottom: 24,
+  },
+
+  // ── Instance hero ──
+  heroWrapper: {
+    marginHorizontal: 10,
+    marginTop: AVATAR_HALF + 10, // space above for avatar overflow
+    marginBottom: 4,
+    position: 'relative',
+  },
+  heroCover: {
+    backgroundColor: '#111',
+    borderRadius: 16,
+    overflow: 'hidden',
+    paddingTop: AVATAR_HALF + 14, // clears the avatar
+    paddingHorizontal: 20,
+    paddingBottom: 20,
+  },
+  heroBg: {
+    position: 'absolute',
+    width: 260,
+    height: 260,
+    borderRadius: 130,
+    backgroundColor: '#2a2a2a',
+    top: -100,
+    right: -80,
+  },
+  heroAvatarRow: {
+    position: 'absolute',
+    top: -AVATAR_HALF,
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+  },
+  heroAvatarCircle: {
+    width: AVATAR_SIZE,
+    height: AVATAR_SIZE,
+    borderRadius: AVATAR_HALF,
+    backgroundColor: '#fff',
+    borderWidth: 4,
+    borderColor: '#f2f2f2', // matches page background
+    justifyContent: 'center',
+    alignItems: 'center',
+    overflow: 'hidden',
+  },
+  heroAvatarImg: {
+    width: AVATAR_SIZE - 16,
+    height: AVATAR_SIZE - 16,
+    borderRadius: (AVATAR_SIZE - 16) / 2,
+  },
+  heroAvatarSpinner: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  // Skeleton elements
+  skelAvatar: {
+    backgroundColor: '#333',
+  },
+  skelTitle: {
+    height: 24,
+    width: 160,
+    borderRadius: 6,
+    backgroundColor: '#333',
+    marginBottom: 4,
+  },
+  skelPill: {
+    height: 24,
+    width: 100,
+    borderRadius: 20,
+    backgroundColor: '#333',
+  },
+  heroContent: {
+    alignItems: 'center',
+    gap: 10,
+  },
+  heroName: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    color: '#fff',
+    letterSpacing: 0.3,
+    textAlign: 'center',
+  },
+  heroPills: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    gap: 6,
+  },
+  heroPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    backgroundColor: '#2a2a2a',
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 20,
+  },
+  heroPillText: {
+    fontSize: 11,
+    color: 'rgba(255,255,255,0.8)',
+    fontFamily: 'monospace',
+  },
+
+  // ── Session card ──
   card: {
     marginBottom: 12,
     marginTop: 10,
     marginHorizontal: 10,
   },
-  label: {
-    fontSize: 13,
-    color: '#555',
-    marginBottom: 4,
-    marginTop: 8,
-  },
-  row: {
+  infoRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 8,
+    marginBottom: 6,
+    marginTop: 4,
   },
-  urlInput: {
-    flex: 1,
+  infoText: {
+    fontSize: 15,
+    fontWeight: 'bold',
+    color: '#222',
+  },
+  detail: {
+    fontSize: 13,
+    color: '#444',
+    marginBottom: 4,
+  },
+  logoutBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginTop: 12,
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: 8,
     borderWidth: 1,
-    borderColor: '#ccc',
-    borderRadius: 6,
-    paddingHorizontal: 10,
-    paddingVertical: 6,
+    borderColor: '#c0392b',
+    alignSelf: 'flex-start',
+  },
+  logoutBtnText: {
+    color: '#c0392b',
+    fontWeight: 'bold',
     fontSize: 14,
   },
-  saveBtn: {
-    backgroundColor: '#555',
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-    borderRadius: 6,
+
+  // ── Instructions ──
+  instructionsBox: {
+    backgroundColor: '#f0f4ff',
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 14,
+    gap: 10,
   },
-  saveBtnText: {
+  instructionsTitle: {
+    fontSize: 13,
+    fontWeight: 'bold',
+    color: '#333',
+    marginBottom: 4,
+  },
+  instructionStep: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 10,
+  },
+  instructionNum: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    backgroundColor: '#1976D2',
+    color: '#fff',
+    fontSize: 11,
+    fontWeight: 'bold',
+    textAlign: 'center',
+    lineHeight: 20,
+    overflow: 'hidden',
+  },
+  instructionText: {
+    flex: 1,
+    fontSize: 13,
+    color: '#444',
+    lineHeight: 18,
+  },
+  instructionBold: {
+    fontWeight: 'bold',
+    color: '#222',
+  },
+  instructionUrl: {
+    fontFamily: 'monospace',
+    fontSize: 11,
+    color: '#1976D2',
+  },
+
+  // ── Scan button ──
+  scanBtn: {
+    backgroundColor: 'rgb(0,122,255)',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    paddingVertical: 16,
+    borderRadius: 10,
+    marginTop: 4,
+  },
+  scanBtnText: {
     color: '#fff',
     fontWeight: 'bold',
-    fontSize: 13,
+    fontSize: 17,
   },
+
+  // ── Banner ──
   banner: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -246,26 +571,8 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontWeight: 'bold',
   },
-  infoRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 6,
-  },
-  infoText: {
-    fontSize: 15,
-    fontWeight: 'bold',
-    color: '#222',
-  },
-  detail: {
-    fontSize: 13,
-    color: '#444',
-    marginBottom: 4,
-  },
-  hint: {
-    fontSize: 12,
-    color: '#888',
-    marginTop: 6,
-  },
+
+  // ── Loading overlay ──
   loginOverlay: {
     ...StyleSheet.absoluteFillObject,
     backgroundColor: 'rgba(0,0,0,0.55)',
@@ -284,21 +591,5 @@ const styles = StyleSheet.create({
     width: '100%',
     height: 6,
     borderRadius: 3,
-  },
-  button: {
-    backgroundColor: 'rgb(0,122,255)',
-    paddingHorizontal: 14,
-    paddingVertical: 8,
-    borderRadius: 6,
-    alignSelf: 'flex-start',
-    marginTop: 10,
-  },
-  buttonDisabled: {
-    backgroundColor: '#aaa',
-  },
-  buttonText: {
-    color: 'white',
-    fontWeight: 'bold',
-    fontSize: 14,
   },
 });

--- a/src/screens/ReadNFCScreen.js
+++ b/src/screens/ReadNFCScreen.js
@@ -1,164 +1,445 @@
 import Clipboard from '@react-native-clipboard/clipboard';
 import {useFocusEffect} from '@react-navigation/native';
-import React, {useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {
   ActivityIndicator,
-  NativeEventEmitter,
-  NativeModules,
-  Platform,
+  Animated,
   ScrollView,
+  StyleSheet,
   Text,
+  TouchableOpacity,
   View,
 } from 'react-native';
-import {Button, Card, Paragraph, Title} from 'react-native-paper';
+import {Card as PaperCard} from 'react-native-paper';
+import Ionicons from 'react-native-vector-icons/Ionicons';
 import Toast from 'react-native-toast-message';
+import NfcManager, {Ndef, NfcTech} from 'react-native-nfc-manager';
 import Ntag424 from '../class/Ntag424';
-import NfcManager, {NfcTech, Ndef} from 'react-native-nfc-manager';
+import {useLaWallet} from '../providers/LaWallet';
 
-export default function ReadNFCScreen(props) {
-  const [cardReadInfo, setCardReadInfo] = useState('');
-  const [ndef, setNdef] = useState('pending...');
-  const [cardUID, setCardUID] = useState();
-  const [key0Changed, setKey0Changed] = useState('Key 0 version pending');
-  const [key1Changed, setKey1Changed] = useState('Key 1 version pending');
-  const [key2Changed, setKey2Changed] = useState('Key 2 version pending');
-  const [key3Changed, setKey3Changed] = useState('Key 3 version pending');
-  const [key4Changed, setKey4Changed] = useState('Key 4 version pending');
+// ─── Constants ───────────────────────────────────────────────────────────────
 
-  const [readyToRead, setReadyToRead] = useState(false);
-  const [readError, setReadError] = useState(null);
+const CARD_TYPES = {
+  '01': 'MIFARE DESFire',
+  '02': 'MIFARE Plus',
+  '03': 'MIFARE Ultralight',
+  '04': 'NTAG',
+  '07': 'NTAG I2C',
+  '08': 'MIFARE DESFire Light',
+};
 
-  const copyToClipboard = () => {
-    Clipboard.setString(cardUID);
-    Toast.show({
-      type: 'success',
-      text1: 'Copied to clipboard'
-    });
-  };
+// ─── Helpers ─────────────────────────────────────────────────────────────────
 
-  const readNfc = async () => {
-    setReadError(null);
-    setKey0Changed("Key 0 version pending");
-    setKey1Changed("Key 1 version pending");
-    setKey2Changed("Key 2 version pending");
-    setKey3Changed("Key 3 version pending");
-    setKey4Changed("Key 4 version pending");
-    setCardReadInfo(null);
-    setNdef(null);
-    setReadyToRead(true);
+function formatDate(iso) {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  });
+}
+
+function shortKey(pk) {
+  if (!pk) return '—';
+  return `${pk.slice(0, 8)}…${pk.slice(-4)}`;
+}
+
+function InfoRow({label, value, mono, onCopy}) {
+  return (
+    <View style={styles.infoRow}>
+      <Text style={styles.infoLabel}>{label}</Text>
+      <View style={styles.infoValueWrap}>
+        <Text
+          style={[styles.infoValue, mono && styles.infoValueMono]}
+          numberOfLines={1}
+          ellipsizeMode="middle">
+          {value}
+        </Text>
+        {onCopy && (
+          <TouchableOpacity onPress={onCopy} style={styles.copyBtn}>
+            <Ionicons name="copy-outline" size={14} color="#888" />
+          </TouchableOpacity>
+        )}
+      </View>
+    </View>
+  );
+}
+
+// ─── Screen ──────────────────────────────────────────────────────────────────
+
+export default function ReadNFCScreen() {
+  const {authFetch, isLogged} = useLaWallet();
+
+  // step: 'reading' | 'result' | 'error'
+  const [step, setStep] = useState('reading');
+  const [errorMsg, setErrorMsg] = useState(null);
+
+  // NFC chip data
+  const [chipUID, setChipUID] = useState(null);
+  const [ndefUrl, setNdefUrl] = useState(null);
+  const [chipInfo, setChipInfo] = useState(null); // {type, vendor, mem}
+  const [keyVersions, setKeyVersions] = useState(null); // string[5]
+
+  // Server card data
+  const [serverCard, setServerCard] = useState(null);
+  const [serverLoading, setServerLoading] = useState(false);
+
+  // Pulse animation for the NFC icon
+  const pulse = useRef(new Animated.Value(1)).current;
+  const pulseAnim = useRef(null);
+
+  // Monotonic token identifying the current scan. Leaving the tab (blur) or
+  // starting a new scan bumps it; any in-flight scan whose token is stale must
+  // not touch state — its NFC request was cancelled by us, not failed.
+  const readSeq = useRef(0);
+
+  useEffect(() => {
+    if (step === 'reading') {
+      pulseAnim.current = Animated.loop(
+        Animated.sequence([
+          Animated.timing(pulse, {
+            toValue: 1.25,
+            duration: 800,
+            useNativeDriver: true,
+          }),
+          Animated.timing(pulse, {
+            toValue: 1.0,
+            duration: 800,
+            useNativeDriver: true,
+          }),
+        ]),
+      );
+      pulseAnim.current.start();
+    } else {
+      pulseAnim.current?.stop();
+      pulse.setValue(1);
+    }
+  }, [step, pulse]);
+
+  // ── Core NFC read ───────────────────────────────────────────────────────────
+
+  const readNfc = useCallback(async () => {
+    // Claim this scan slot. The cleanup increments readSeq so any
+    // in-flight scan from a previous focus session sees a mismatch
+    // and exits silently instead of showing an error.
+    const mySeq = ++readSeq.current;
+
+    setStep('reading');
+    setErrorMsg(null);
+    setChipUID(null);
+    setNdefUrl(null);
+    setChipInfo(null);
+    setKeyVersions(null);
+    setServerCard(null);
 
     try {
       await NfcManager.requestTechnology(NfcTech.IsoDep);
       const tag = await NfcManager.getTag();
 
-      const ndefMessage = Ndef.uri.decodePayload(tag.ndefMessage[0].payload);
-      setNdef(ndefMessage);
+      // ── NDEF URL ──
+      let resolvedUrl = null;
+      try {
+        resolvedUrl = Ndef.uri.decodePayload(tag.ndefMessage[0].payload);
+      } catch {}
+      setNdefUrl(resolvedUrl);
 
+      // ── Chip UID ──
+      const uid = tag.id?.toLowerCase() ?? null;
+      setChipUID(uid);
+
+      // ── Card version / type ──
       await Ntag424.isoSelectFileApplication();
-      const cardVersion = await Ntag424.getVersion();
-      const cardTypes = {
-        '01': 'MIFARE DESFire',
-        '02': 'MIFARE Plus',
-        '03': 'MIFARE Ultralight',
-        '04': 'NTAG',
-        '05': 'RFU',
-        '06': 'RFU',
-        '07': 'NTAG I2C',
-        '08': 'MIFARE DESFire Light',
-      };
-      setCardReadInfo(`Tagname: ${cardTypes.hasOwnProperty(cardVersion.HWType) ? cardTypes[cardVersion.HWType]: ''}\nUID:${tag.id} \nTotalMem: ${cardVersion.HWStorageSize == '11' ? 'Between 256B and 512B' : 'RFU'}\nVendor: ${cardVersion.VendorID == '04' ? "NXP" : "Non NXP"}`);
+      const ver = await Ntag424.getVersion();
+      setChipInfo({
+        type: CARD_TYPES[ver.HWType] ?? `Type ${ver.HWType}`,
+        vendor: ver.VendorID === '04' ? 'NXP' : `Vendor ${ver.VendorID}`,
+        mem: ver.HWStorageSize === '11' ? '256–512 B' : `Size ${ver.HWStorageSize}`,
+      });
 
-      setCardUID(tag.id);
-      const key0Version = await Ntag424.getKeyVersion("00");
-      // console.log('key0', key0Version);
-      setKey0Changed("Key 0 version: "+key0Version);
-      const key1Version = await Ntag424.getKeyVersion("01");
-      setKey1Changed("Key 1 version: "+key1Version);
-      const key2Version = await Ntag424.getKeyVersion("02");
-      setKey2Changed("Key 2 version: "+key2Version);
-      const key3Version = await Ntag424.getKeyVersion("03");
-      setKey3Changed("Key 3 version: "+key3Version);
-      const key4Version = await Ntag424.getKeyVersion("04");
-      setKey4Changed("Key 4 version: "+key4Version);
-      
-      
-    } catch (ex) {
-      console.warn('Oops!', ex);
-      var error = ex;
-      if(typeof ex === 'object') {
-        error = "NFC Error: "+(ex.message? ex.message : ex.constructor.name);
-      }
-      setReadError(error);
-    } finally {
-      // stop the nfc scanning
+      // ── Key versions ──
+      const kvs = await Promise.all(
+        ['00', '01', '02', '03', '04'].map(n => Ntag424.getKeyVersion(n)),
+      );
+      setKeyVersions(kvs);
+
       await NfcManager.cancelTechnologyRequest();
-      setReadyToRead(false);
+
+      // Only update state if this scan wasn't cancelled by a tab switch
+      if (mySeq !== readSeq.current) return;
+
+      setStep('result');
+
+      // ── Server lookup (non-blocking) ──
+      if (uid) {
+        // Try NDEF URL card ID first, fall back to chip UID
+        let cardId = uid;
+        if (resolvedUrl) {
+          const m = resolvedUrl.match(/\/api\/cards\/([^/\?]+)/);
+          if (m) cardId = m[1];
+        }
+        fetchServerCard(cardId);
+      }
+    } catch (ex) {
+      await NfcManager.cancelTechnologyRequest().catch(() => {});
+      // If the scan was cancelled because we left the tab, swallow the
+      // error — useFocusEffect will restart a fresh scan on return.
+      if (mySeq !== readSeq.current) return;
+      const msg =
+        typeof ex === 'object'
+          ? 'NFC Error: ' + (ex.message ?? ex.constructor.name)
+          : String(ex);
+      setErrorMsg(msg);
+      setStep('error');
     }
+  }, [authFetch, isLogged]);
+
+  const fetchServerCard = useCallback(
+    async cardId => {
+      if (!isLogged) return;
+      setServerLoading(true);
+      try {
+        const res = await authFetch('/api/cards/' + cardId);
+        if (res.ok) {
+          setServerCard(await res.json());
+        }
+      } catch {}
+      setServerLoading(false);
+    },
+    [authFetch, isLogged],
+  );
+
+  // Auto-start when screen gains focus; cancel + invalidate when it loses focus
+  useFocusEffect(
+    useCallback(() => {
+      readNfc();
+      return () => {
+        // Bump the sequence so the in-flight catch block exits silently
+        readSeq.current++;
+        NfcManager.cancelTechnologyRequest().catch(() => {});
+      };
+    }, [readNfc]),
+  );
+
+  const copyUID = useCallback(() => {
+    if (!chipUID) return;
+    Clipboard.setString(chipUID);
+    Toast.show({type: 'success', text1: 'UID copied to clipboard'});
+  }, [chipUID]);
+
+  // ─── Render ─────────────────────────────────────────────────────────────────
+
+  // Reading state — centred pulsing icon
+  if (step === 'reading') {
+    return (
+      <View style={styles.readingCenter}>
+        <Animated.View style={{transform: [{scale: pulse}]}}>
+          <Ionicons name="wifi-outline" size={96} color="#f58340" style={styles.nfcIcon} />
+        </Animated.View>
+        <Text style={styles.readingTitle}>Ready to Scan</Text>
+        <Text style={styles.readingSubtitle}>
+          Hold your card to the back of the phone
+        </Text>
+      </View>
+    );
   }
 
+  // Error state
+  if (step === 'error') {
+    return (
+      <View style={styles.readingCenter}>
+        <Ionicons name="alert-circle-outline" size={64} color="#c0392b" />
+        <Text style={styles.errorTitle}>Read Failed</Text>
+        <Text style={styles.errorMsg}>{errorMsg}</Text>
+        <TouchableOpacity style={styles.retryBtn} onPress={readNfc}>
+          <Ionicons name="refresh" size={16} color="#fff" style={{marginRight: 6}} />
+          <Text style={styles.retryBtnText}>Try Again</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  // Result state
   return (
-    <ScrollView style={{}}>
-      {readyToRead ? 
-        <Text
-          style={{
-            margin: 20,
-            fontWeight: 'bold',
-            fontSize: 15,
-            textAlign: 'center',
-          }}>
-          <ActivityIndicator /> Hold NFC card to Reader
-        </Text>
-        :
-        <View style={{marginHorizontal: 10, marginVertical: 20, flexDirection: 'row', justifyContent: 'center'}}>
-          <Button icon="nfc" mode="contained" onPress={readNfc} compact={true} color="#f79928">Read NFC</Button>
-        </View>
-      }
-      {readError && (
-        <Card style={{marginBottom: 20, marginHorizontal: 10}}>
-        <Card.Content>
-          <Title>Tag Read Error</Title>
-          <Paragraph style={{fontWeight: 'bold', fontSize: 15}}>
-            {readError}
-          </Paragraph>
-        </Card.Content>
-      </Card>
-            )}
-      <Card style={{marginBottom: 20, marginHorizontal: 10}}>
-        <Card.Content>
-          <Title>NDEF Record</Title>
-          <Paragraph style={{fontWeight: 'bold', fontSize: 15}}>
-            {ndef}
-          </Paragraph>
-        </Card.Content>
-      </Card>
-      <Card style={{marginBottom: 20, marginHorizontal: 10}}>
-        <Card.Content>
-          <Title>Card UID</Title>
-          <View style={{alignItems: 'flex-start', flexDirection: 'row'}}>
-            {cardUID && <Button onPress={copyToClipboard} mode="contained" color="#f79928">Copy</Button>}
-            <Text style={{lineHeight: 35, marginLeft: 10}}>{cardUID}</Text>
+    <ScrollView style={styles.scroll} contentContainerStyle={styles.scrollContent}>
+
+      {/* Header icon + tap-again button */}
+      <View style={styles.resultHeader}>
+        <Ionicons name="wifi" size={40} color="#f58340" />
+        <Text style={styles.resultHeaderText}>Card Read</Text>
+        <TouchableOpacity style={styles.scanAgainBtn} onPress={readNfc}>
+          <Ionicons name="refresh" size={15} color="#f58340" style={{marginRight: 4}} />
+          <Text style={styles.scanAgainText}>Scan Again</Text>
+        </TouchableOpacity>
+      </View>
+
+      {/* Server card data */}
+      {isLogged && (
+        <PaperCard style={styles.card}>
+          <PaperCard.Content>
+            <View style={styles.cardHeader}>
+              <Ionicons name="server-outline" size={18} color="#555" />
+              <Text style={styles.cardTitle}>LaWallet Record</Text>
+              {serverLoading && <ActivityIndicator size="small" color="#f58340" style={{marginLeft: 8}} />}
+            </View>
+            {serverCard ? (
+              <>
+                <InfoRow
+                  label="Owner"
+                  value={serverCard.username ?? shortKey(serverCard.pubkey)}
+                />
+                <InfoRow label="Design" value={serverCard.design?.description ?? '—'} />
+                <InfoRow label="Kind" value={serverCard.kind ?? '—'} />
+                <InfoRow label="Created" value={formatDate(serverCard.createdAt)} />
+                <InfoRow
+                  label="Last used"
+                  value={serverCard.lastUsedAt ? formatDate(serverCard.lastUsedAt) : 'Never'}
+                />
+              </>
+            ) : !serverLoading ? (
+              <Text style={styles.notFound}>Card not registered in this system.</Text>
+            ) : null}
+          </PaperCard.Content>
+        </PaperCard>
+      )}
+
+      {/* NFC chip data */}
+      <PaperCard style={styles.card}>
+        <PaperCard.Content>
+          <View style={styles.cardHeader}>
+            <Ionicons name="hardware-chip-outline" size={18} color="#555" />
+            <Text style={styles.cardTitle}>Chip Data</Text>
           </View>
-        </Card.Content>
-      </Card>
-      <Card style={{marginBottom: 20, marginHorizontal: 10}}>
-        <Card.Content>
-          <Title>NFC Card Attributes</Title>
-          <Paragraph>{cardReadInfo}</Paragraph>
-        </Card.Content>
-      </Card>
+          <InfoRow label="UID" value={chipUID ?? '—'} mono onCopy={copyUID} />
+          <InfoRow label="NDEF URL" value={ndefUrl ?? '—'} mono />
+          {chipInfo && (
+            <>
+              <InfoRow label="Type" value={chipInfo.type} />
+              <InfoRow label="Vendor" value={chipInfo.vendor} />
+              <InfoRow label="Memory" value={chipInfo.mem} />
+            </>
+          )}
+        </PaperCard.Content>
+      </PaperCard>
 
-      <Card style={{marginBottom: 20, marginHorizontal: 10}}>
-        <Card.Content>
-          <Title>Card Keys</Title>
-          <Paragraph>{key0Changed}</Paragraph>
-          <Paragraph>{key1Changed}</Paragraph>
-          <Paragraph>{key2Changed}</Paragraph>
-          <Paragraph>{key3Changed}</Paragraph>
-          <Paragraph>{key4Changed}</Paragraph>
-        </Card.Content>
-      </Card>
+      {/* Key versions */}
+      {keyVersions && (
+        <PaperCard style={styles.card}>
+          <PaperCard.Content>
+            <View style={styles.cardHeader}>
+              <Ionicons name="key-outline" size={18} color="#555" />
+              <Text style={styles.cardTitle}>Key Versions</Text>
+            </View>
+            {keyVersions.map((v, i) => (
+              <InfoRow key={i} label={`Key ${i}`} value={v ?? '—'} mono />
+            ))}
+          </PaperCard.Content>
+        </PaperCard>
+      )}
 
-      <Text></Text>
+      <View style={{height: 24}} />
     </ScrollView>
   );
 }
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  // Reading / error centered layout
+  readingCenter: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 40,
+    gap: 16,
+  },
+  nfcIcon: {
+    transform: [{rotate: '90deg'}], // wifi icon rotated looks like NFC waves
+  },
+  readingTitle: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#333',
+    marginTop: 8,
+  },
+  readingSubtitle: {
+    fontSize: 15,
+    color: '#888',
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+  errorTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: '#c0392b',
+    marginTop: 8,
+    textAlign: 'center',
+  },
+  errorMsg: {
+    fontSize: 14,
+    color: '#555',
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  retryBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#f58340',
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 8,
+    marginTop: 8,
+  },
+  retryBtnText: {color: '#fff', fontWeight: 'bold', fontSize: 15},
+
+  // Result layout
+  scroll: {backgroundColor: '#f2f2f2'},
+  scrollContent: {padding: 12},
+  resultHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    marginBottom: 12,
+    paddingHorizontal: 4,
+  },
+  resultHeaderText: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: '#333',
+    flex: 1,
+  },
+  scanAgainBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: '#f58340',
+  },
+  scanAgainText: {color: '#f58340', fontSize: 13, fontWeight: '600'},
+
+  // Cards
+  card: {marginBottom: 12},
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginBottom: 12,
+  },
+  cardTitle: {fontSize: 15, fontWeight: 'bold', color: '#444'},
+  notFound: {fontSize: 13, color: '#999', fontStyle: 'italic'},
+
+  // Info rows
+  infoRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#eee',
+  },
+  infoLabel: {fontSize: 13, color: '#888', flex: 1},
+  infoValueWrap: {flex: 2, flexDirection: 'row', justifyContent: 'flex-end', alignItems: 'center', gap: 6},
+  infoValue: {fontSize: 13, color: '#333', textAlign: 'right', flexShrink: 1},
+  infoValueMono: {fontFamily: 'monospace', fontSize: 11},
+  copyBtn: {padding: 4},
+});

--- a/src/screens/WipeCardScreen.tsx
+++ b/src/screens/WipeCardScreen.tsx
@@ -1,0 +1,542 @@
+import React, {useCallback, useRef, useState} from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import {useFocusEffect} from '@react-navigation/native';
+import {Card as PaperCard} from 'react-native-paper';
+import Ionicons from 'react-native-vector-icons/Ionicons';
+import NfcManager, {Ndef, NfcTech} from 'react-native-nfc-manager';
+import Ntag424 from '../class/Ntag424';
+import {useLaWallet} from '../providers/LaWallet';
+import {Card} from '../types/response';
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const ZERO_KEY = '00000000000000000000000000000000';
+
+type Step =
+  | 'tap'
+  | 'reading'
+  | 'loading'
+  | 'info'
+  | 'writing'
+  | 'success'
+  | 'error';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function formatDate(iso?: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function shortKey(pk?: string | null): string {
+  if (!pk) return '—';
+  return `${pk.slice(0, 8)}…${pk.slice(-4)}`;
+}
+
+function InfoRow({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <View style={styles.infoRow}>
+      <Text style={styles.infoLabel}>{label}</Text>
+      <Text
+        style={[styles.infoValue, mono && styles.infoValueMono]}
+        numberOfLines={1}
+        ellipsizeMode="middle">
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+// ─── Screen ──────────────────────────────────────────────────────────────────
+
+export default function WipeCardScreen() {
+  const {authFetch, isLogged} = useLaWallet();
+
+  const [step, setStep] = useState<Step>('tap');
+  const [cardId, setCardId] = useState<string | null>(null);
+  const [card, setCard] = useState<Card | null>(null);
+  const [progress, setProgress] = useState<string[]>([]);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const addProgress = useCallback((msg: string) => {
+    setProgress(prev => [...prev, msg]);
+  }, []);
+
+  // True while a tab-blur cancel is in flight so catch blocks can
+  // distinguish "user switched tabs" from a genuine NFC error.
+  const cancelledByBlur = useRef(false);
+  // Tracks the step at the moment blur fires (avoids stale closure).
+  const stepRef = useRef<Step>('tap');
+  // Keep stepRef in sync with step state.
+  const setStepSynced = useCallback((s: Step) => {
+    stepRef.current = s;
+    setStep(s);
+  }, []);
+
+  // Cancel NFC and restore clean state whenever the tab loses focus.
+  useFocusEffect(
+    useCallback(() => {
+      return () => {
+        const currentStep = stepRef.current;
+        if (currentStep === 'reading' || currentStep === 'writing') {
+          cancelledByBlur.current = true;
+          NfcManager.cancelTechnologyRequest().catch(() => {});
+        }
+      };
+    }, []),
+  );
+
+  const reset = () => {
+    setStepSynced('tap');
+    setCardId(null);
+    setCard(null);
+    setProgress([]);
+    setErrorMsg(null);
+  };
+
+  const handleError = useCallback((msg: string) => {
+    setErrorMsg(msg);
+    setStepSynced('error');
+    NfcManager.cancelTechnologyRequest().catch(() => {});
+  }, [setStepSynced]);
+
+  // ── Phase 1: tap card to resolve ID ────────────────────────────────────────
+
+  const startTap = useCallback(async () => {
+    cancelledByBlur.current = false;
+    setStepSynced('reading');
+    setErrorMsg(null);
+    try {
+      await NfcManager.requestTechnology(NfcTech.IsoDep, {
+        alertMessage: 'Hold your card to the back of your phone',
+      });
+      const tag = await NfcManager.getTag();
+      if (!tag) {
+        if (cancelledByBlur.current) { cancelledByBlur.current = false; setStepSynced('tap'); return; }
+        handleError('No card detected. Try again.');
+        return;
+      }
+
+      // Primary: use chip UID
+      let resolvedId: string = (tag as any).id?.toLowerCase() ?? '';
+
+      // Fallback: parse card ID out of the lnurlw NDEF URL
+      const ndefMsg = (tag as any).ndefMessage;
+      if (ndefMsg?.length) {
+        try {
+          const url: string = Ndef.uri.decodePayload(ndefMsg[0].payload);
+          const m = url.match(/\/api\/cards\/([^/\?]+)/);
+          if (m) resolvedId = m[1];
+        } catch {
+          // ignore NDEF parse errors — chip UID is the fallback
+        }
+      }
+
+      NfcManager.cancelTechnologyRequest().catch(() => {});
+
+      if (!resolvedId) {
+        handleError('Could not read card ID.');
+        return;
+      }
+
+      setCardId(resolvedId);
+      setStepSynced('loading');
+
+      // ── Phase 2: fetch card info from server ──────────────────────────────
+      const res = await authFetch('/api/cards/' + resolvedId);
+      if (res.status === 404) { handleError('Card not registered in this system.'); return; }
+      if (!res.ok) { handleError(`Server error (${res.status}) fetching card details.`); return; }
+      const data: Card = await res.json();
+      setCard(data);
+      setStepSynced('info');
+    } catch (e: any) {
+      // Swallow the error if the blur handler triggered the cancel.
+      if (cancelledByBlur.current) {
+        cancelledByBlur.current = false;
+        setStepSynced('tap');
+        return;
+      }
+      handleError(e?.message ?? 'NFC read failed.');
+    }
+  }, [authFetch, handleError, setStepSynced]);
+
+  // ── Phase 3: confirmation dialog ───────────────────────────────────────────
+
+  const handleResetPress = () => {
+    Alert.alert(
+      'Reset card?',
+      'This will permanently wipe all keys on the physical card and delete it from the server. This cannot be undone.',
+      [
+        {text: 'Cancel', style: 'cancel'},
+        {text: 'Reset', style: 'destructive', onPress: startWipe},
+      ],
+    );
+  };
+
+  // ── Phase 4: NFC wipe + server delete ──────────────────────────────────────
+
+  const startWipe = useCallback(async () => {
+    if (!card) return;
+    cancelledByBlur.current = false;
+    setProgress([]);
+    setStepSynced('writing');
+
+    const {k0, k1, k2, k3, k4} = card.ntag424;
+    const id = card.id;
+
+    try {
+      await NfcManager.requestTechnology(NfcTech.IsoDep, {
+        alertMessage: 'Hold card steady while keys are wiped…',
+      });
+
+      // Authenticate with current key 0
+      await Ntag424.AuthEv2First('00', k0);
+
+      // Clear file settings (removes SDM / mirroring config)
+      await Ntag424.resetFileSettings();
+
+      // Wipe keys 1–4 (current → zeros). Key 0 must be last
+      // because the session was opened with it.
+      await Ntag424.changeKey('01', k1, ZERO_KEY, '00');
+      addProgress('✓ Key 1 wiped');
+      await Ntag424.changeKey('02', k2, ZERO_KEY, '00');
+      addProgress('✓ Key 2 wiped');
+      await Ntag424.changeKey('03', k3, ZERO_KEY, '00');
+      addProgress('✓ Key 3 wiped');
+      await Ntag424.changeKey('04', k4, ZERO_KEY, '00');
+      addProgress('✓ Key 4 wiped');
+      await Ntag424.changeKey('00', k0, ZERO_KEY, '00');
+      addProgress('✓ Key 0 wiped');
+
+      // Clear NDEF message
+      const bytes = Ndef.encodeMessage([Ndef.uriRecord('')]);
+      await Ntag424.setNdefMessage(bytes);
+      addProgress('✓ NDEF cleared');
+
+      NfcManager.cancelTechnologyRequest().catch(() => {});
+
+      // Delete card record from server
+      try {
+        const delRes = await authFetch('/api/cards/' + id, {
+          method: 'DELETE',
+        });
+        if (!delRes.ok) {
+          addProgress(
+            '⚠ Card wiped but server delete failed — contact your admin.',
+          );
+        } else {
+          addProgress('✓ Card deleted from server');
+        }
+      } catch {
+        addProgress(
+          '⚠ Card wiped but server delete failed — contact your admin.',
+        );
+      }
+
+      setStepSynced('success');
+    } catch (e: any) {
+      NfcManager.cancelTechnologyRequest().catch(() => {});
+      // If blur triggered the cancel, go back to info (user can retry).
+      if (cancelledByBlur.current) {
+        cancelledByBlur.current = false;
+        setStepSynced('info');
+        return;
+      }
+      const msg = e?.message ?? 'NFC write failed.';
+      addProgress('✗ Error: ' + msg);
+      handleError('Wipe failed: ' + msg);
+    }
+  }, [card, authFetch, addProgress, handleError, setStepSynced]);
+
+  // ─── Render ─────────────────────────────────────────────────────────────────
+
+  // Not logged in
+  if (!isLogged) {
+    return (
+      <View style={styles.center}>
+        <Ionicons name="lock-closed-outline" size={56} color="#aaa" />
+        <Text style={styles.emptyTitle}>Not logged in</Text>
+        <Text style={styles.emptySubtitle}>
+          Go to the Login tab to authenticate first.
+        </Text>
+      </View>
+    );
+  }
+
+  // Tap prompt
+  if (step === 'tap') {
+    return (
+      <View style={styles.center}>
+        <Ionicons name="card-outline" size={72} color="#f58340" />
+        <Text style={styles.emptyTitle}>Wipe Card</Text>
+        <Text style={styles.emptySubtitle}>
+          Tap a card to load its details and reset its keys.
+        </Text>
+        <TouchableOpacity style={styles.primaryBtn} onPress={startTap}>
+          <Text style={styles.primaryBtnText}>Tap Card</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  // NFC reading / server loading
+  if (step === 'reading' || step === 'loading') {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" color="#f58340" />
+        <Text style={styles.loadingText}>
+          {step === 'reading'
+            ? 'Hold your card to the back of the phone…'
+            : 'Fetching card details…'}
+        </Text>
+      </View>
+    );
+  }
+
+  // Error
+  if (step === 'error') {
+    return (
+      <View style={styles.center}>
+        <Ionicons name="alert-circle-outline" size={56} color="#c0392b" />
+        <Text style={styles.errorTitle}>Something went wrong</Text>
+        <Text style={styles.errorMsg}>{errorMsg}</Text>
+        <TouchableOpacity style={styles.secondaryBtn} onPress={reset}>
+          <Text style={styles.secondaryBtnText}>Try Again</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  // NFC wipe in progress
+  if (step === 'writing') {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" color="#f58340" />
+        <Text style={styles.loadingText}>Hold card steady while keys are wiped…</Text>
+        <ScrollView
+          style={styles.progressBox}
+          contentContainerStyle={styles.progressContent}>
+          {progress.map((p, i) => (
+            <Text key={i} style={styles.progressLine}>
+              {p}
+            </Text>
+          ))}
+        </ScrollView>
+      </View>
+    );
+  }
+
+  // Success
+  if (step === 'success') {
+    return (
+      <View style={styles.center}>
+        <Ionicons name="checkmark-circle-outline" size={72} color="#27ae60" />
+        <Text style={styles.successTitle}>Card Wiped Successfully</Text>
+        <ScrollView
+          style={styles.progressBox}
+          contentContainerStyle={styles.progressContent}>
+          {progress.map((p, i) => (
+            <Text key={i} style={styles.progressLine}>
+              {p}
+            </Text>
+          ))}
+        </ScrollView>
+        <TouchableOpacity style={styles.primaryBtn} onPress={reset}>
+          <Text style={styles.primaryBtnText}>Done</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  // Card info (step === 'info')
+  return (
+    <ScrollView style={styles.scroll}>
+      <PaperCard style={styles.card}>
+        <PaperCard.Content>
+          <View style={styles.infoHeader}>
+            <Ionicons name="card" size={26} color="#f58340" />
+            <Text style={styles.infoTitle}>Card Details</Text>
+          </View>
+
+          <InfoRow
+            label="Owner"
+            value={card?.username ?? shortKey(card?.pubkey)}
+          />
+          <InfoRow label="Created" value={formatDate(card?.createdAt)} />
+          <InfoRow
+            label="Last used"
+            value={card?.lastUsedAt ? formatDate(card.lastUsedAt) : 'Never'}
+          />
+          <InfoRow
+            label="Design"
+            value={card?.design?.description ?? '—'}
+          />
+          <InfoRow label="Kind" value={card?.kind ?? '—'} />
+          <InfoRow label="Card ID" value={cardId ?? '—'} mono />
+        </PaperCard.Content>
+      </PaperCard>
+
+      <TouchableOpacity style={styles.dangerBtn} onPress={handleResetPress}>
+        <Ionicons
+          name="trash-outline"
+          size={18}
+          color="#fff"
+          style={{marginRight: 8}}
+        />
+        <Text style={styles.dangerBtnText}>Reset Keys</Text>
+      </TouchableOpacity>
+
+      <TouchableOpacity style={styles.cancelBtn} onPress={reset}>
+        <Text style={styles.cancelBtnText}>Cancel</Text>
+      </TouchableOpacity>
+    </ScrollView>
+  );
+}
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  scroll: {padding: 12},
+  center: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 32,
+    gap: 16,
+  },
+  // Empty / not-logged-in states
+  emptyTitle: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    color: '#333',
+    marginTop: 8,
+    textAlign: 'center',
+  },
+  emptySubtitle: {
+    fontSize: 14,
+    color: '#888',
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  // Loading
+  loadingText: {
+    fontSize: 15,
+    color: '#555',
+    textAlign: 'center',
+    marginTop: 12,
+  },
+  // Error
+  errorTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: '#c0392b',
+    marginTop: 8,
+    textAlign: 'center',
+  },
+  errorMsg: {
+    fontSize: 14,
+    color: '#555',
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  // Success
+  successTitle: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    color: '#27ae60',
+    marginTop: 8,
+    textAlign: 'center',
+  },
+  // Progress log
+  progressBox: {
+    maxHeight: 200,
+    width: '100%',
+    borderWidth: 1,
+    borderColor: '#eee',
+    borderRadius: 8,
+    backgroundColor: '#f9f9f9',
+    marginTop: 8,
+  },
+  progressContent: {padding: 12},
+  progressLine: {
+    fontSize: 13,
+    color: '#333',
+    marginBottom: 4,
+    fontFamily: 'monospace',
+  },
+  // Buttons
+  primaryBtn: {
+    backgroundColor: '#f58340',
+    paddingHorizontal: 40,
+    paddingVertical: 14,
+    borderRadius: 8,
+    marginTop: 8,
+  },
+  primaryBtnText: {color: '#fff', fontWeight: 'bold', fontSize: 16},
+  secondaryBtn: {
+    backgroundColor: '#555',
+    paddingHorizontal: 28,
+    paddingVertical: 12,
+    borderRadius: 8,
+    marginTop: 8,
+  },
+  secondaryBtnText: {color: '#fff', fontWeight: 'bold', fontSize: 14},
+  dangerBtn: {
+    backgroundColor: '#c0392b',
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingVertical: 14,
+    borderRadius: 8,
+    marginBottom: 12,
+  },
+  dangerBtnText: {color: '#fff', fontWeight: 'bold', fontSize: 16},
+  cancelBtn: {
+    paddingVertical: 12,
+    alignItems: 'center',
+    marginBottom: 24,
+  },
+  cancelBtnText: {color: '#888', fontSize: 14},
+  // Info card
+  card: {marginBottom: 16},
+  infoHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 16,
+  },
+  infoTitle: {fontSize: 18, fontWeight: 'bold', color: '#333'},
+  infoRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#eee',
+  },
+  infoLabel: {fontSize: 13, color: '#888', flex: 1},
+  infoValue: {fontSize: 13, color: '#333', flex: 2, textAlign: 'right'},
+  infoValueMono: {fontFamily: 'monospace', fontSize: 11},
+});

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -46,6 +46,23 @@ export type Card = {
   kind: string;
 };
 
+export type InstanceSettings = {
+  community_name: string;
+  domain: string;
+  endpoint: string;
+  subdomain: string;
+  brand_theme: string;       // hex color e.g. "#22c55e"
+  brand_rounding: 'Small' | 'Medium' | 'Large';
+  logotype_url: string;      // full logo with text
+  isotypo_url: string;       // icon / isotype
+  maintenance_enabled: string;
+  social_twitter?: string;
+  social_discord?: string;
+  social_nostr?: string;
+  social_email?: string;
+  social_website?: string;
+};
+
 export type Ntag424WriteData = {
   card_name: string;
   id: string;


### PR DESCRIPTION
## Summary

Second round of UX work on top of the merged scan-UX PR (#6). Adds a full **tap-to-wipe** card flow, makes **Login** instance-aware (driven entirely by the device JWT), and overhauls the **Bulk Create** and **Read NFC** screens — with consistent NFC lifecycle handling so scans are cancelled cleanly when leaving a tab.

## What changed

### 🗑️ Wipe Card (new screen)
- `src/screens/WipeCardScreen.tsx` — tap a card → fetch its details (`GET /api/cards/{id}`) → confirm → wipe NTAG424 keys to zeros over NFC → delete the record (`DELETE /api/cards/{id}`).
- Card ID resolved from the chip UID, falling back to the lnurlw URL in the NDEF message.
- Gated behind login; tab placed left of **Login**.

### 🎨 Bulk Create
- Replaced the dropdown with a **Select Skin** gallery: vertical card list, search filter, and a refresh button that refetches designs.
- **Single-tap selection**, guarded so taps during/just after a scroll don't accidentally select.
- Card images shown **in full** (measured aspect ratio, no cropping).
- Selected card is shown during the **"Hold card to phone"** phase and inside the **key-writing dialog** so the operator always sees what's being written.

### 🔐 Login
- Removed the base-URL input — the base URL is now taken from the JWT's `apiUrl` claim.
- Added an **instance hero** (name / logo / domain / endpoint) fetched from `/api/settings`, plus a session card and loading/animation states.

### 📖 Read NFC
- Auto-reads on focus with a pulsing NFC icon; on tap, fetches and displays the server card record alongside chip data.

### 🧩 Provider & types
- `LaWallet.tsx`: adopt `apiUrl` from the JWT and fetch card designs on hydration, so the logged-in instance's skins display instead of the bundled fallback list.
- `jwt.ts`: added the `apiUrl` claim. `response.ts`: added `InstanceSettings` and extended `Card`.

### 🧷 Reliability
- All three NFC screens cancel in-flight reads on **tab blur** and **manual cancel**, and suppress message-less cancellation errors that previously surfaced as **blank alerts**.

## Why
The operator should never have to type a server URL (it's in the token), should always see which design is being written, and shouldn't hit stray "Read failed" / blank alerts when switching tabs or cancelling a scan. Wipe Card closes the lifecycle by safely retiring a card end-to-end.

## Reviewer notes
- **No server changes** — `DELETE /api/cards/{id}` already exists with the `cards:write` scope carried by the device JWT.
- **NFC requires hardware** — the writing dialog and wipe flow can only be exercised by tapping a physical NTAG424 card; gallery/selection/scroll behavior and the blank-alert fix were verified on-device via adb.

## Test plan
- [x] Log in by scanning a device token → base URL + instance hero populate from the JWT.
- [x] Bulk Create: search, single-tap select (no select while scrolling), write a card (design visible while holding + writing).
- [x] Wipe Card: tap a registered card → details → confirm → keys wiped → card deleted.
- [x] Switch tabs / cancel mid-scan on each NFC screen → no "Read failed" and no blank alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
