### PR TITLE
fix: prevent startup & camera hangs on Android 16 / Pixel 9

### DIFF
--- a/android/app/src/main/java/com/lightningnfcapp/SecureStorageModule.java
+++ b/android/app/src/main/java/com/lightningnfcapp/SecureStorageModule.java
@@ -73,7 +73,7 @@ public class SecureStorageModule extends ReactContextBaseJavaModule {
         try {
             getPrefs().edit().putString(key, value).apply();
             promise.resolve(null);
-        } catch (GeneralSecurityException | IOException e) {
+        } catch (Throwable e) {
             Log.w(Constants.TAG, "SecureStorage.setItem: corruption detected, retrying", e);
             recoverFromCorruption();
             try {
@@ -89,7 +89,7 @@ public class SecureStorageModule extends ReactContextBaseJavaModule {
     public void getItem(String key, Promise promise) {
         try {
             promise.resolve(getPrefs().getString(key, null));
-        } catch (GeneralSecurityException | IOException e) {
+        } catch (Throwable e) {
             Log.w(Constants.TAG, "SecureStorage.getItem: corruption detected, clearing store", e);
             recoverFromCorruption();
             // Return null so the caller treats it as "no stored value" and forces re-login.
@@ -102,7 +102,7 @@ public class SecureStorageModule extends ReactContextBaseJavaModule {
         try {
             getPrefs().edit().remove(key).apply();
             promise.resolve(null);
-        } catch (GeneralSecurityException | IOException e) {
+        } catch (Throwable e) {
             Log.w(Constants.TAG, "SecureStorage.removeItem: corruption detected, clearing store", e);
             recoverFromCorruption();
             promise.resolve(null);
@@ -114,7 +114,7 @@ public class SecureStorageModule extends ReactContextBaseJavaModule {
         try {
             getPrefs().edit().clear().apply();
             promise.resolve(null);
-        } catch (GeneralSecurityException | IOException e) {
+        } catch (Throwable e) {
             Log.w(Constants.TAG, "SecureStorage.clear: corruption detected, force clearing", e);
             recoverFromCorruption();
             promise.resolve(null);

--- a/src/providers/LaWallet.tsx
+++ b/src/providers/LaWallet.tsx
@@ -119,9 +119,13 @@ export const LaWalletProvider = ({children}: {children: React.ReactNode}) => {
   useEffect(() => {
     (async () => {
       try {
+        // Never let a stalled native storage call hang app startup: race each
+        // read against a timeout that resolves to null ("no stored value").
+        const readTimeout = (): Promise<null> =>
+          new Promise(res => setTimeout(() => res(null), 4000));
         const [storedUrl, storedToken] = await Promise.all([
-          SecureStorage.getItem(STORAGE_KEYS.BASE_URL),
-          SecureStorage.getItem(STORAGE_KEYS.DEVICE_TOKEN),
+          Promise.race([SecureStorage.getItem(STORAGE_KEYS.BASE_URL), readTimeout()]),
+          Promise.race([SecureStorage.getItem(STORAGE_KEYS.DEVICE_TOKEN), readTimeout()]),
         ]);
         if (storedUrl) applyBaseUrl(storedUrl);
         if (storedToken) {

--- a/src/screens/ScanScreen.js
+++ b/src/screens/ScanScreen.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {Alert, Button, StyleSheet} from 'react-native';
+import {Alert, Button, PermissionsAndroid, Platform, StyleSheet} from 'react-native';
 import Clipboard from '@react-native-clipboard/clipboard';
 
 import {useCameraDevices} from 'react-native-vision-camera';
@@ -23,8 +23,28 @@ export default function ScanScreen({route, navigation}) {
 
   React.useEffect(() => {
     (async () => {
-      const status = await Camera.requestCameraPermission();
-      setHasPermission(status === 'authorized');
+      try {
+        if (Platform.OS === 'android') {
+          // vision-camera v2's requestCameraPermission() can hang on newer
+          // Android, so use RN's PermissionsAndroid which resolves reliably.
+          const already = await PermissionsAndroid.check(
+            PermissionsAndroid.PERMISSIONS.CAMERA,
+          );
+          if (already) {
+            setHasPermission(true);
+            return;
+          }
+          const res = await PermissionsAndroid.request(
+            PermissionsAndroid.PERMISSIONS.CAMERA,
+          );
+          setHasPermission(res === PermissionsAndroid.RESULTS.GRANTED);
+        } else {
+          const status = await Camera.requestCameraPermission();
+          setHasPermission(status === 'authorized');
+        }
+      } catch (e) {
+        console.log('[ScanScreen] permission ERROR: ' + String(e));
+      }
     })();
   }, []);
 


### PR DESCRIPTION
## Summary

Fixes the app launching to a **blank Login** and the QR scanner showing a **blank/white camera** on newer hardware (verified on a **Pixel 9 Pro XL / Android 16**). All three were the same class of bug: an old-stack native call that never resolved its bridge Promise, hanging the JS that awaited it.

## Root causes & fixes

### 1. `SecureStorageModule` keystore exception → blank Login
`getItem()` only caught `GeneralSecurityException` / `IOException`, but `EncryptedSharedPreferences.create()` throws a **keystore `RuntimeException`** on this device. The uncaught exception left the bridge `Promise` unresolved, so `LaWallet` hydration hung and `isLoading` stayed `true` — and the logged-out Login view renders `null` while `isLoading`, i.e. a blank screen.
**Fix:** catch `Throwable` in every method so the module always resolves (falling back to “no stored value”) and can never hang.

### 2. Hydration backstop
**Fix:** race each hydration storage read against a 4s timeout, so app startup can never block on a stalled native call even if storage misbehaves.

### 3. vision-camera permission hang → blank scanner
vision-camera v2's `Camera.requestCameraPermission()` **hangs on Android 16**, so `hasPermission` never became `true` and `ScanScreen`'s `device != null && hasPermission` guard rendered nothing.
**Fix:** on Android, use React Native's `PermissionsAndroid.check`/`request` (the camera permission is already granted) which resolves reliably. iOS keeps the vision-camera path.

## Testing
- Verified on a Pixel 9 Pro XL (Android 16), fresh debug build:
  - Login screen renders the Session card + “Scan device token”.
  - **Scan device token → live camera preview** with ML Kit QR scanning active (`CameraDevice.onOpened`, frames flowing). No hang, no blank/white.

## Notes / follow-ups (out of scope here)
- The **“not 16 KB compatible”** developer warning still appears (the RN 0.72-era native libs aren't 16 KB-aligned). It's informational on a 4 KB-mode device; full 16 KB support would need an RN/NDK upgrade.
- Separate pre-existing crash spotted: `MainActivity.onNewIntent` (line ~302) NPEs calling `.equals()` on a null intent action when handling NFC intents — worth a follow-up fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
