### PR TITLE
fix: show full endpoint URL on Login (not just the domain)

### DIFF
--- a/src/screens/Login.tsx
+++ b/src/screens/Login.tsx
@@ -115,7 +115,7 @@ function InstanceHero({settings}: {settings: InstanceSettings}) {
             <View style={styles.heroPill}>
               <Ionicons name="server-outline" size={11} color="rgba(255,255,255,0.75)" />
               <Text style={styles.heroPillText} numberOfLines={1}>
-                {settings.endpoint.replace(/^https?:\/\//, '')}
+                {settings.endpoint}
               </Text>
             </View>
           </View>
@@ -266,6 +266,9 @@ export default function LoginScreen({route}) {
                   <Ionicons name="checkmark-circle" size={18} color="green" />
                   <Text style={styles.infoText}> Logged in</Text>
                 </View>
+                <Text style={styles.detail} numberOfLines={1}>
+                  Endpoint: {baseUrl}
+                </Text>
                 <Text style={styles.detail}>Pubkey: {shortPubkey}</Text>
                 <Text style={styles.detail}>
                   Scopes: {scopes.join(', ') || '—'}


### PR DESCRIPTION
The Login Session card now shows `Endpoint: <baseUrl>` (the full connected URL), always visible even when the instance hero (/api/settings) doesn't load. The hero's endpoint pill no longer strips the scheme either.

Verified on-device: shows `https://…trycloudflare.com` in full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)