### PR TITLE
chore: update references for rename to card-installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ local.properties
 .cxx/
 *.keystore
 !debug.keystore
+# Production upload signing key — NEVER commit (already covered by *.keystore;
+# kept explicit for clarity). Back it up off-machine; git is not a backup.
+android/app/my-upload-key.keystore
 
 # node.js
 #

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Android app to provision and wipe **NTAG424 DNA** NFC cards as Boltcards for a
 blank card to write its keys and `lnurlw`, or tap a programmed card to wipe it — a
 contactless, paywave-like experience for the Lightning Network.
 
-> This is the [**lawalletio**](https://github.com/lawalletio/bolt-nfc-android-app)
+> This is the [**lawalletio**](https://github.com/lawalletio/card-installer)
 > fork of [boltcard/bolt-nfc-android-app](https://github.com/boltcard/bolt-nfc-android-app),
 > with LaWallet integration, instance-aware QR-JWT login, a bulk-provisioning flow,
 > tap-to-wipe, and **license-free native NFC**.
@@ -14,7 +14,7 @@ Android only.
 
 ## Current version
 
-**v0.3.0** — see the [latest release](https://github.com/lawalletio/bolt-nfc-android-app/releases/latest).
+**v0.3.0** — see the [latest release](https://github.com/lawalletio/card-installer/releases/latest).
 
 ## What's different in this fork
 
@@ -39,7 +39,7 @@ Android only.
 ## Install
 
 Download the APK from the
-[latest release](https://github.com/lawalletio/bolt-nfc-android-app/releases/latest)
+[latest release](https://github.com/lawalletio/card-installer/releases/latest)
 and install it on your Android phone.
 
 > ⚠️ Release APKs are currently **signed with the debug key** (the production
@@ -94,7 +94,7 @@ Requires Android Studio + Android SDK installed separately
 
 ```bash
 git clone <repo>
-cd bolt-nfc-android-app
+cd card-installer
 yarn setup       # installs SDKMAN, nvm, Zulu 11, Node 18.15, yarn, JS deps
 ```
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# One-shot dev environment bootstrap for bolt-nfc-android-app.
+# One-shot dev environment bootstrap for card-installer.
 # Installs SDKMAN (Java manager), nvm (Node manager), the pinned JDK and Node,
 # then yarn install. Idempotent — safe to re-run.
 #


### PR DESCRIPTION
Follow-up to the repo rename (`bolt-nfc-android-app` → `card-installer`): updates README links + clone dir, the setup.sh comment, and adds an explicit .gitignore entry for the upload keystore. 🤖 Generated with [Claude Code](https://claude.com/claude-code)