### PR TITLE
docs: add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2024 Rob Clarkson
+Copyright (c) 2026 LaWallet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -195,6 +195,12 @@ Various fixes to attempt to prevent card programming errors.
 ### 0.1.4
 Added support for random UID to increase privacy.
 
+## License
+
+[MIT](LICENSE). This is a fork of
+[boltcard/bolt-nfc-android-app](https://github.com/boltcard/bolt-nfc-android-app)
+(also MIT); the original copyright is retained in the LICENSE alongside the fork's.
+
 ## More
 
 - [Card programming errors](card-programming-errors.md)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "cardinstaller",
   "version": "0.3.1",
   "private": true,
+  "license": "MIT",
   "scripts": {
     "setup": "./scripts/setup.sh",
     "android": "react-native run-android",


### PR DESCRIPTION
Adds an MIT `LICENSE` (retains the upstream boltcard copyright + adds the fork's), sets `package.json` license to MIT, and adds a README License section. Upstream is also MIT. 🤖 Generated with [Claude Code](https://claude.com/claude-code)