### PR TITLE
chore: bump version to 0.3.2

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -112,8 +112,8 @@ android {
         applicationId "com.lacrypta.cardinstaller"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 26
-        versionName "0.3.1"
+        versionCode 27
+        versionName "0.3.2"
         // Restrict native builds to the configured ABI(s). With ABI splits
         // disabled, this is what actually keeps the (universal) APK arm64-only
         // and stops third-party CMake modules (vision-camera) from building

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cardinstaller",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Release bump for v0.3.2 (first production-signed build + Zapstore publish). 🤖 Generated with [Claude Code](https://claude.com/claude-code)