### PR TITLE
fix: zapstore:link keystore .p12 conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ local.properties
 # Production upload signing key — NEVER commit (already covered by *.keystore;
 # kept explicit for clarity). Back it up off-machine; git is not a backup.
 android/app/my-upload-key.keystore
+# PKCS12 / PFX keystores (e.g. the .p12 zsp uses for identity linking).
+*.p12
+*.pfx
 
 # node.js
 #

--- a/scripts/release-zapstore.sh
+++ b/scripts/release-zapstore.sh
@@ -37,8 +37,12 @@ export KEYSTORE_PASSWORD="${KEYSTORE_PASSWORD:-$(grep -E '^MYAPP_UPLOAD_STORE_PA
 if [ "${1:-}" = "link" ]; then
   [ -f "$KEYSTORE" ] || { echo "✗ keystore not found: $KEYSTORE"; exit 1; }
   [ -n "${KEYSTORE_PASSWORD:-}" ] || { echo "✗ KEYSTORE_PASSWORD not found in $GRADLE_PROPS"; exit 1; }
-  echo "→ Linking $KEYSTORE to your Nostr identity (one-time)…"
-  exec zsp identity --link-key "$KEYSTORE"
+  # zsp picks the keystore format from the file extension (.keystore => JKS),
+  # but ours is PKCS12 — give it a .p12 copy in a temp dir (cleaned on exit).
+  TMPD="$(mktemp -d)"; trap 'rm -rf "$TMPD"' EXIT
+  cp "$KEYSTORE" "$TMPD/upload.p12"
+  echo "→ Linking signing key to your Nostr identity (one-time)…"
+  zsp identity --link-key "$TMPD/upload.p12"
 fi
 
 # --- build a production-signed release APK ---------------------------------


### PR DESCRIPTION
zsp rejects the .keystore extension (assumes JKS); convert our PKCS12 keystore to a temp .p12 for `zsp identity --link-key`, and gitignore *.p12/*.pfx. 🤖 Generated with [Claude Code](https://claude.com/claude-code)