### PR TITLE
fix: wipe flow fetches reset keys from /wipe endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,10 @@ keytool -genkeypair -v -keystore android/app/my-upload-key.keystore \
 2. **Bulk Create** — pick a card design, tap **Tap Card to Write**, then hold a blank
    NTAG424 card to the phone. The progress ring fills clockwise as the keys and
    `lnurlw` are written and verified. Provision more cards by tapping them in turn.
-3. **Wipe Card** — tap a programmed card; the app reads its UID, fetches its keys,
-   wipes all keys to zero, clears the NDEF, and deletes the card server-side.
+3. **Wipe Card** — tap a programmed card; the app reads its UID, fetches the reset
+   keys from the server's `/api/cards/:id/wipe` endpoint (which also **unpairs** the
+   card from its user), wipes all keys to zero over NFC, clears the NDEF, and deletes
+   the card server-side.
 4. **Read NFC** — tap any card to inspect its `lnurlw` URL and PICC/CMAC parameters.
 
 > ⚠️ Writing/wiping is destructive. If you lose a card's keys you may be unable to
@@ -174,8 +176,10 @@ keytool -genkeypair -v -keystore android/app/my-upload-key.keystore \
 
 ## Security
 
-- NTAG424 keys are generated and held by your LaWallet / Boltcard server; the app
-  fetches them over an authenticated session to write or wipe cards.
+- NTAG424 keys are generated and held by your LaWallet / Boltcard server. Regular
+  card reads (`GET /api/cards/:id`) never expose them — the app fetches keys only
+  from the dedicated `/write` (program) and `/wipe` (reset) endpoints, each of which
+  **unpairs** the card from its user as a side effect of exporting its keys.
 - Keep your keys secret and avoid other listening NFC devices in range while writing.
 - Do **not** commit signing credentials. If real keystore passwords were ever
   committed to `android/gradle.properties`, rotate them and move the values to

--- a/src/screens/WipeCardScreen.tsx
+++ b/src/screens/WipeCardScreen.tsx
@@ -13,7 +13,7 @@ import Ionicons from 'react-native-vector-icons/Ionicons';
 import NfcManager, {Ndef, NfcTech} from 'react-native-nfc-manager';
 import Ntag424 from '../class/Ntag424';
 import {useLaWallet} from '../providers/LaWallet';
-import {Card} from '../types/response';
+import {Card, Ntag424WipeData} from '../types/response';
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -199,10 +199,19 @@ export default function WipeCardScreen() {
     setProgress([]);
     setStepSynced('writing');
 
-    const {k0, k1, k2, k3, k4} = card.ntag424;
     const id = card.id;
 
     try {
+      // Read responses no longer carry the NTAG424 keys — fetch the reset
+      // payload from the dedicated /wipe endpoint. NOTE: fetching it unpairs the
+      // card from its user server-side (it's deleted below anyway).
+      const keysRes = await authFetch('/api/cards/' + id + '/wipe');
+      if (!keysRes.ok) {
+        handleError(`Server error (${keysRes.status}) fetching reset keys.`);
+        return;
+      }
+      const {k0, k1, k2, k3, k4} = (await keysRes.json()) as Ntag424WipeData;
+
       // Clear any stale NFC request so requestTechnology doesn't fail with
       // "one request at a time" when arriving from another NFC screen.
       await NfcManager.start().catch(() => {});

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -22,13 +22,11 @@ export type CardDesign = {
   archivedAt?: string | null;
 };
 
-export type Ntag424Keys = {
+// Public NTAG424 fields returned by the read endpoints (GET /api/cards[/:id]).
+// Keys are NOT included — they are only exported by the /write and /wipe
+// endpoints (both of which unpair the card server-side).
+export type Ntag424Public = {
   cid: string;
-  k0: string;
-  k1: string;
-  k2: string;
-  k3: string;
-  k4: string;
   ctr: number;
   createdAt: string;
 };
@@ -36,7 +34,7 @@ export type Ntag424Keys = {
 export type Card = {
   id: string; // server-generated hex id (NOT the chip uid)
   design: {id: string; imageUrl: string; description: string; createdAt: string};
-  ntag424: Ntag424Keys;
+  ntag424: Ntag424Public;
   createdAt: string;
   title?: string;
   lastUsedAt?: string;
@@ -74,4 +72,17 @@ export type Ntag424WriteData = {
   lnurlw_base: string; // lnurlw://<host>/api/cards/<id>/scan
   protocol_name: 'new_bolt_card_response';
   protocol_version: '1';
+};
+
+// Reset payload from GET /api/cards/:id/wipe. Keys are top-level (not nested
+// under `ntag424`). Fetching this endpoint unpairs the card server-side.
+export type Ntag424WipeData = {
+  action: 'wipe';
+  k0: string;
+  k1: string;
+  k2: string;
+  k3: string;
+  k4: string;
+  uid: string;
+  version: 1;
 };


### PR DESCRIPTION
## Problem
The **Wipe Card** flow fetched NTAG424 keys from `GET /api/cards/:id` and read `card.ntag424.{k0..k4}`. The server's keys-lockdown change removed keys from read responses — they're now returned only by `GET /api/cards/:id/write` (program) and `GET /api/cards/:id/wipe` (reset), both of which also **unpair** the card. So `card.ntag424` no longer carries keys and `Ntag424.AuthEv2First('00', undefined)` failed → wipe broken.

## Fix
- `WipeCardScreen.startWipe` now fetches the reset payload from `GET /api/cards/:id/wipe` (keys at top level: `{action, k0..k4, uid, version}`) instead of reading `card.ntag424`. Fetching it inside `startWipe` (on confirm) means the server-side unpair happens only when the user actually wipes.
- Types: `Card.ntag424` is now the keyless read shape (`Ntag424Public`); added `Ntag424WipeData`.
- README: clarified the wipe flow + that the key-export endpoints (`/write`, `/wipe`) unpair the card.

The program/bulk-create flow is unaffected — it already fetches keys from `/write`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)