### PR TITLE
fix: program flow mints a one-time /write token (replay protection)

### DIFF
--- a/src/screens/CreateBulkBoltcardScreen.tsx
+++ b/src/screens/CreateBulkBoltcardScreen.tsx
@@ -22,7 +22,7 @@ import NfcManager, {NfcTech} from 'react-native-nfc-manager';
 import WriteModal from '../components/WriteModal';
 
 import {useLaWallet, AuthError} from '../providers/LaWallet';
-import {Ntag424WriteData} from '../types/response';
+import {Ntag424WriteData, WriteTokenResponse} from '../types/response';
 import {Skin} from '../types/skin';
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -215,21 +215,15 @@ export default function CreateBulkBoltcardScreen() {
         const cardId: string = createdCard.id;
 
         let writeData: Ntag424WriteData;
-        try {
-          const writeRes = await fetch(`${baseUrl}/api/cards/${cardId}/write`);
-          if (writeRes.ok) {
-            writeData = await writeRes.json();
-          } else {
-            throw new Error(`write endpoint returned ${writeRes.status}`);
-          }
-        } catch (writeErr) {
-          console.warn('CreateBulk: write endpoint failed, using POST keys', writeErr);
+        // Host used only by the degraded fallback below. The happy path takes
+        // the server-derived public host from the /write response instead.
+        const host = (() => {
+          try { return new URL(baseUrl).host; }
+          catch { return baseUrl.replace(/^https?:\/\//, '').split('/')[0]; }
+        })();
+        const fallbackFromPost = (): Ntag424WriteData => {
           const ntag = createdCard.ntag424;
-          const host = (() => {
-            try { return new URL(baseUrl).host; }
-            catch { return baseUrl.replace(/^https?:\/\//, '').split('/')[0]; }
-          })();
-          writeData = {
+          return {
             card_name: createdCard.title || 'New Card',
             id: ntag.cid,
             k0: ntag.k0, k1: ntag.k1, k2: ntag.k2, k3: ntag.k3, k4: ntag.k4,
@@ -237,6 +231,46 @@ export default function CreateBulkBoltcardScreen() {
             protocol_name: 'new_bolt_card_response',
             protocol_version: '1',
           };
+        };
+        try {
+          // `/write` is now replay-protected: mint a single-use token first
+          // (authenticated; succeeds while the card is fresh — a just-created
+          // card always is), then fetch `/write` with it. We anchor the GET on
+          // `baseUrl` (the reachable instance host) using the RAW token, not the
+          // mint response's public-domain `url`, since the two can differ. The
+          // response's `lnurlw_base` still carries the correct server-derived
+          // public host, so the chip is programmed with the right scan URL.
+          const mintRes = await authFetch(`/api/cards/${cardId}/write-token`, {
+            method: 'POST',
+            body: JSON.stringify({}),
+          });
+          if (!mintRes.ok) {
+            throw new Error(`write-token mint returned ${mintRes.status}`);
+          }
+          const {token} = (await mintRes.json()) as WriteTokenResponse;
+          if (!token) {
+            throw new Error('write-token response missing token');
+          }
+          const writeRes = await fetch(
+            `${baseUrl}/api/cards/${cardId}/write?token=${encodeURIComponent(
+              token,
+            )}`,
+          );
+          if (!writeRes.ok) {
+            throw new Error(`write endpoint returned ${writeRes.status}`);
+          }
+          writeData = await writeRes.json();
+        } catch (writeErr) {
+          // An expired session must surface the re-login prompt (handled by the
+          // outer catch), not silently degrade to the fallback.
+          if (writeErr instanceof AuthError) {
+            throw writeErr;
+          }
+          console.warn(
+            'CreateBulk: tokenized write failed, using POST keys',
+            writeErr,
+          );
+          writeData = fallbackFromPost();
         }
 
         setCardData(writeData);

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -74,6 +74,16 @@ export type Ntag424WriteData = {
   protocol_version: '1';
 };
 
+// Response of POST /api/cards/:id/write-token — a single-use, replay-protected
+// programming token. `url` is the public-domain `/write?token=…` URL (for a
+// scanned QR); `token` is also returned raw so a client talking to the instance
+// on a different host can build its own `<base>/api/cards/:id/write?token=…`.
+export type WriteTokenResponse = {
+  token: string;
+  url: string;
+  expiresAt: string;
+};
+
 // Reset payload from GET /api/cards/:id/wipe. Keys are top-level (not nested
 // under `ntag424`). Fetching this endpoint unpairs the card server-side.
 export type Ntag424WipeData = {


### PR DESCRIPTION
## Why

lawallet-nwc made the BoltCard programming endpoint **replay-protected**. `GET /api/cards/:id/write` (which hands out the NTAG424 keys) now **requires a single-use `?token=`** minted by `POST /api/cards/:id/write-token` — valid only while the card is *fresh* (never tapped), consumed on the first fetch, and `403`s otherwise. This stops the key-export URL from being replayed to clone a card.

That broke the bulk programming flow: `CreateBulkBoltcardScreen` fetched `/write` **unauthenticated and untokenized**, which now returns `403`.

## What this does

In `CreateBulkBoltcardScreen` (the only screen that writes NTAG424 cards), after creating the card:

1. **Mint** a one-time token: `authFetch('POST /api/cards/:id/write-token')` → `{ token, url, expiresAt }`. A just-created card is always fresh, so this succeeds.
2. **Fetch** `/write` anchored on the reachable `baseUrl` host using the **raw `token`**: `${baseUrl}/api/cards/:id/write?token=…`. We deliberately do *not* fetch the mint response's `url` — it uses the server's **public LUD-16 domain**, which can differ from (and be unreachable from) the instance host the device is bound to.
3. The `/write` **response body** still carries the server-derived `lnurlw_base`, so the **correct public scan host** is burned onto the chip regardless of which host we fetched from.

### Resilience
- **Fallback retained**: if the mint or tokenized fetch fails (older server without `/write-token`, network error), it falls back to the keys from the `POST /api/cards` response + a `baseUrl`-derived `lnurlw_base` — exactly today's behavior. Works against both upgraded and legacy servers.
- **Session expiry**: an `AuthError` (401) re-throws to the outer handler so the re-login prompt still shows, instead of silently degrading.

No other flow is affected — wipe/read/link/scan were verified to either not touch `/write` or use authenticated `authFetch`.

## Companion change (lawallet-nwc)
The mint endpoint now also returns the **raw `token`** (additive, backward-compatible — the admin web modal uses `url` and ignores it) so clients on a different host than the public domain can build their own reachable write URL.

## Verification
- `tsc --noEmit`: clean (0 errors); added `WriteTokenResponse` type.
- Server side independently verified end-to-end: mint→200, `/write` no-token→403, valid→200+keys, reuse→403 (single-use), tapped→409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)